### PR TITLE
get travis CI green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 
 matrix:
   include:
-    - go: 1.6
-    - go: 1.7
     - go: 1.8
     - go: 1.9
     - go: tip

--- a/cmd/protoc-gen-grpchan/gen_test_pb_test.go
+++ b/cmd/protoc-gen-grpchan/gen_test_pb_test.go
@@ -33,34 +33,14 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type Test struct {
-	Id                   int64    `protobuf:"varint,1,opt,name=id" json:"id,omitempty"`
-	Name                 string   `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	Id   int64  `protobuf:"varint,1,opt,name=id" json:"id,omitempty"`
+	Name string `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
 }
 
 func (m *Test) Reset()                    { *m = Test{} }
 func (m *Test) String() string            { return proto.CompactTextString(m) }
 func (*Test) ProtoMessage()               {}
 func (*Test) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *Test) Unmarshal(b []byte) error {
-	return xxx_messageInfo_Test.Unmarshal(m, b)
-}
-func (m *Test) Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_Test.Marshal(b, m, deterministic)
-}
-func (dst *Test) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Test.Merge(dst, src)
-}
-func (m *Test) XXX_Size() int {
-	return xxx_messageInfo_Test.Size(m)
-}
-func (m *Test) XXX_DiscardUnknown() {
-	xxx_messageInfo_Test.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_Test proto.InternalMessageInfo
 
 func (m *Test) GetId() int64 {
 	if m != nil {

--- a/grpchantesting/test.pb.go
+++ b/grpchantesting/test.pb.go
@@ -34,38 +34,18 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type Message struct {
-	Payload              []byte            `protobuf:"bytes,1,opt,name=payload,proto3" json:"payload,omitempty"`
-	Count                int32             `protobuf:"varint,2,opt,name=count" json:"count,omitempty"`
-	Code                 int32             `protobuf:"varint,3,opt,name=code" json:"code,omitempty"`
-	DelayMillis          int32             `protobuf:"varint,4,opt,name=delay_millis,json=delayMillis" json:"delay_millis,omitempty"`
-	Headers              map[string]string `protobuf:"bytes,5,rep,name=headers" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Trailers             map[string]string `protobuf:"bytes,6,rep,name=trailers" json:"trailers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `protobuf_unrecognized:"proto3" json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Payload     []byte            `protobuf:"bytes,1,opt,name=payload,proto3" json:"payload,omitempty"`
+	Count       int32             `protobuf:"varint,2,opt,name=count" json:"count,omitempty"`
+	Code        int32             `protobuf:"varint,3,opt,name=code" json:"code,omitempty"`
+	DelayMillis int32             `protobuf:"varint,4,opt,name=delay_millis,json=delayMillis" json:"delay_millis,omitempty"`
+	Headers     map[string]string `protobuf:"bytes,5,rep,name=headers" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Trailers    map[string]string `protobuf:"bytes,6,rep,name=trailers" json:"trailers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 }
 
 func (m *Message) Reset()                    { *m = Message{} }
 func (m *Message) String() string            { return proto.CompactTextString(m) }
 func (*Message) ProtoMessage()               {}
 func (*Message) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *Message) Unmarshal(b []byte) error {
-	return xxx_messageInfo_Message.Unmarshal(m, b)
-}
-func (m *Message) Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_Message.Marshal(b, m, deterministic)
-}
-func (dst *Message) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Message.Merge(dst, src)
-}
-func (m *Message) XXX_Size() int {
-	return xxx_messageInfo_Message.Size(m)
-}
-func (m *Message) XXX_DiscardUnknown() {
-	xxx_messageInfo_Message.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_Message proto.InternalMessageInfo
 
 func (m *Message) GetPayload() []byte {
 	if m != nil {
@@ -111,8 +91,6 @@ func (m *Message) GetTrailers() map[string]string {
 
 func init() {
 	proto.RegisterType((*Message)(nil), "grpchantesting.Message")
-	proto.RegisterMapType((map[string]string)(nil), "grpchantesting.Message.HeadersEntry")
-	proto.RegisterMapType((map[string]string)(nil), "grpchantesting.Message.TrailersEntry")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/httpgrpc/httpgrpc.pb.go
+++ b/httpgrpc/httpgrpc.pb.go
@@ -32,35 +32,15 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 // call, to encode the GRPC status code and any trailer metadata. This
 // message is only used in GRPC responses, not in requests.
 type HttpTrailer struct {
-	Metadata             map[string]*TrailerValues `protobuf:"bytes,1,rep,name=metadata" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Code                 int32                     `protobuf:"varint,2,opt,name=code" json:"code,omitempty"`
-	Message              string                    `protobuf:"bytes,3,opt,name=message" json:"message,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
-	XXX_unrecognized     []byte                    `protobuf_unrecognized:"proto3" json:"-"`
-	XXX_sizecache        int32                     `json:"-"`
+	Metadata map[string]*TrailerValues `protobuf:"bytes,1,rep,name=metadata" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Code     int32                     `protobuf:"varint,2,opt,name=code" json:"code,omitempty"`
+	Message  string                    `protobuf:"bytes,3,opt,name=message" json:"message,omitempty"`
 }
 
 func (m *HttpTrailer) Reset()                    { *m = HttpTrailer{} }
 func (m *HttpTrailer) String() string            { return proto.CompactTextString(m) }
 func (*HttpTrailer) ProtoMessage()               {}
 func (*HttpTrailer) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *HttpTrailer) Unmarshal(b []byte) error {
-	return xxx_messageInfo_HttpTrailer.Unmarshal(m, b)
-}
-func (m *HttpTrailer) Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_HttpTrailer.Marshal(b, m, deterministic)
-}
-func (dst *HttpTrailer) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_HttpTrailer.Merge(dst, src)
-}
-func (m *HttpTrailer) XXX_Size() int {
-	return xxx_messageInfo_HttpTrailer.Size(m)
-}
-func (m *HttpTrailer) XXX_DiscardUnknown() {
-	xxx_messageInfo_HttpTrailer.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_HttpTrailer proto.InternalMessageInfo
 
 func (m *HttpTrailer) GetMetadata() map[string]*TrailerValues {
 	if m != nil {
@@ -84,33 +64,13 @@ func (m *HttpTrailer) GetMessage() string {
 }
 
 type TrailerValues struct {
-	Values               []string `protobuf:"bytes,1,rep,name=values" json:"values,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	Values []string `protobuf:"bytes,1,rep,name=values" json:"values,omitempty"`
 }
 
 func (m *TrailerValues) Reset()                    { *m = TrailerValues{} }
 func (m *TrailerValues) String() string            { return proto.CompactTextString(m) }
 func (*TrailerValues) ProtoMessage()               {}
 func (*TrailerValues) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
-func (m *TrailerValues) Unmarshal(b []byte) error {
-	return xxx_messageInfo_TrailerValues.Unmarshal(m, b)
-}
-func (m *TrailerValues) Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_TrailerValues.Marshal(b, m, deterministic)
-}
-func (dst *TrailerValues) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TrailerValues.Merge(dst, src)
-}
-func (m *TrailerValues) XXX_Size() int {
-	return xxx_messageInfo_TrailerValues.Size(m)
-}
-func (m *TrailerValues) XXX_DiscardUnknown() {
-	xxx_messageInfo_TrailerValues.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_TrailerValues proto.InternalMessageInfo
 
 func (m *TrailerValues) GetValues() []string {
 	if m != nil {
@@ -121,7 +81,6 @@ func (m *TrailerValues) GetValues() []string {
 
 func init() {
 	proto.RegisterType((*HttpTrailer)(nil), "fullstorydev.grpchan.httpgrpc.HttpTrailer")
-	proto.RegisterMapType((map[string]*TrailerValues)(nil), "fullstorydev.grpchan.httpgrpc.HttpTrailer.MetadataEntry")
 	proto.RegisterType((*TrailerValues)(nil), "fullstorydev.grpchan.httpgrpc.TrailerValues")
 }
 


### PR DESCRIPTION
The `ci.sh` script reported all good on my machine. But then failed in travis due to a couple of things:
1. I was using protoc-gen-go from the `dev` branch of the golang/protobuf repo. Travis downloads master and uses that. (Code generated from master is compatible with dev, but not vice versa.)
2. Go version matrix was too broad. No need to support Go 1.6.