### PR TITLE
fix generated import statements to not be subject to goimports re-ordering

### DIFF
--- a/cmd/protoc-gen-grpchan/protoc-gen-grpchan.go
+++ b/cmd/protoc-gen-grpchan/protoc-gen-grpchan.go
@@ -102,15 +102,13 @@ func generateChanStubs(fd *desc.FileDescriptor) (*plugin_go.CodeGeneratorRespons
 	w("")
 	w("package %s", pkg)
 	w("")
-	w("import (")
 	for _, imp := range imports.imports {
 		if imp.alias != "" {
-			w("	%s %q", imp.alias, imp.packagePath)
+			w("import %s %q", imp.alias, imp.packagePath)
 		} else {
-			w("	%q", imp.packagePath)
+			w("import %q", imp.packagePath)
 		}
 	}
-	w(")")
 
 	for _, sd := range fd.GetServices() {
 		svcName := export(sd.GetName())


### PR DESCRIPTION
Because the imports were put into a single group, an invocation of `goimports` where one of the imports was a *local* package would cause the imports to be re-ordered.

Ideally, the generated code is stable and not subject to change during calls to `gofmt` and `goimports`. So this makes that so.