### PR TITLE
fix panics

### DIFF
--- a/httpgrpc/client.go
+++ b/httpgrpc/client.go
@@ -40,6 +40,8 @@ var _ grpchan.Channel = (*Channel)(nil)
 // given resp with the server's reply. Client stubs that use HTTP 1.1 should use
 // this method instead of grpc.Invoke.
 func (ch *Channel) Invoke(ctx context.Context, methodName string, req, resp interface{}, opts ...grpc.CallOption) error {
+	// TODO(jh): support call options.. somehow?
+
 	h := headersFromContext(ctx)
 	h.Set("Content-Type", UnaryRpcContentType_V1)
 
@@ -97,6 +99,8 @@ func (ch *Channel) Invoke(ctx context.Context, methodName string, req, resp inte
 // NewStream executes a streaming RPC. Client stubs that use HTTP 1.1 should
 // use this method instead of grpc.NewClientStream.
 func (ch *Channel) NewStream(ctx context.Context, desc *grpc.StreamDesc, methodName string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	// TODO(jh): support call options.. somehow?
+
 	ctx, cancel := context.WithCancel(ctx)
 
 	h := headersFromContext(ctx)

--- a/inprocgrpc/in_process.go
+++ b/inprocgrpc/in_process.go
@@ -155,9 +155,6 @@ func (c *Channel) WithServerStreamInterceptor(interceptor grpc.StreamServerInter
 
 func (c *Channel) Invoke(ctx context.Context, method string, req, resp interface{}, opts ...grpc.CallOption) error {
 	// TODO(jh): support call options.. somehow?
-	if len(opts) > 0 {
-		panic("in-process channel does not support call options")
-	}
 
 	var strs []string
 	if method[0] == '/' {
@@ -202,9 +199,6 @@ func (c *Channel) Invoke(ctx context.Context, method string, req, resp interface
 
 func (c *Channel) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 	// TODO(jh): support call options.. somehow?
-	if len(opts) > 0 {
-		panic("in-process channel does not support call options")
-	}
 
 	var strs []string
 	if method[0] == '/' {


### PR DESCRIPTION
This stuff is getting more use, and I encountered some cases where panics happen.

* We have a case where an interceptor is adding call options. It's actually okay for them to be silently ignored, but the `inprocgrpc.Channel` panics when it sees them. So, for now, we'll silently ignore them (which, as it turns out, is what `httpgrpc.Channel` was already doing.) But I think the TODOs can be addressed soon-ish -- if/when I get https://github.com/grpc/grpc-go/pull/1902 and https://github.com/grpc/grpc-go/pull/1904 merged to the grpc-go project.
* A straight-up bug in `grpchan.InterceptChannel` -- if there were no existing unary interceptor, the intercepted channel would panic during unary calls.
