### PR TITLE
Revert "change Register* function names: move 'Handler' to end (looks better)"

### DIFF
--- a/cmd/protoc-gen-grpchan/protoc-gen-grpchan.go
+++ b/cmd/protoc-gen-grpchan/protoc-gen-grpchan.go
@@ -115,7 +115,7 @@ func generateChanStubs(fd *desc.FileDescriptor) (*plugin_go.CodeGeneratorRespons
 		lowerSvcName := unexport(svcName)
 
 		w("")
-		w("func Register%sHandler(reg grpchan.ServiceRegistry, srv %sServer) {", svcName, svcName)
+		w("func RegisterHandler%s(reg grpchan.ServiceRegistry, srv %sServer) {", svcName, svcName)
 		w("	reg.RegisterService(&_%s_serviceDesc, srv)", svcName)
 		w("}")
 		w("")

--- a/doc.go
+++ b/doc.go
@@ -50,7 +50,7 @@
 //        return &<serverName>ChannelClient{ch}
 //    }
 //
-//    func Register<ServerName>Handler(sr grpchan.ServiceRegistry, srv <ServerName>Server) {
+//    func RegisterHandler<ServerName>(sr grpchan.ServiceRegistry, srv <ServerName>Server) {
 //        s.RegisterService(&_<ServerName>_serviceDesc, srv)
 //    }
 //

--- a/grpchantesting/test.pb.grpchan.go
+++ b/grpchantesting/test.pb.grpchan.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func RegisterTestServiceHandler(reg grpchan.ServiceRegistry, srv TestServiceServer) {
+func RegisterHandlerTestService(reg grpchan.ServiceRegistry, srv TestServiceServer) {
 	reg.RegisterService(&_TestService_serviceDesc, srv)
 }
 

--- a/httpgrpc/httpgrpc_test.go
+++ b/httpgrpc/httpgrpc_test.go
@@ -15,7 +15,7 @@ import (
 func TestGrpcOverHttp(t *testing.T) {
 	svr := &grpchantesting.TestServer{}
 	reg := grpchan.HandlerMap{}
-	grpchantesting.RegisterTestServiceHandler(reg, svr)
+	grpchantesting.RegisterHandlerTestService(reg, svr)
 
 	var mux http.ServeMux
 	httpgrpc.HandleServices(mux.HandleFunc, "/", reg, nil, nil)

--- a/inprocgrpc/in_process_test.go
+++ b/inprocgrpc/in_process_test.go
@@ -10,8 +10,8 @@ import (
 func TestInProcessChannel(t *testing.T) {
 	svr := &grpchantesting.TestServer{}
 
-	var ch inprocgrpc.Channel
-	grpchantesting.RegisterTestServiceHandler(&ch, svr)
+	var cc inprocgrpc.Channel
+	grpchantesting.RegisterHandlerTestService(&cc, svr)
 
-	grpchantesting.RunChannelTestCases(t, &ch, true)
+	grpchantesting.RunChannelTestCases(t, &cc, true)
 }

--- a/intercept_server_test.go
+++ b/intercept_server_test.go
@@ -30,7 +30,7 @@ func TestInterceptServerUnary(t *testing.T) {
 	}
 
 	var successCount, failCount int
-	grpchantesting.RegisterTestServiceHandler(grpchan.WithInterceptor(handlers,
+	grpchantesting.RegisterHandlerTestService(grpchan.WithInterceptor(handlers,
 		func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 			if lastSeen != "a" {
 				// interceptor above should have been invoked first!
@@ -129,7 +129,7 @@ func TestInterceptServerStream(t *testing.T) {
 	handlers := grpchan.HandlerMap{}
 
 	var messageCount, successCount, failCount int
-	grpchantesting.RegisterTestServiceHandler(grpchan.WithInterceptor(handlers, nil,
+	grpchantesting.RegisterHandlerTestService(grpchan.WithInterceptor(handlers, nil,
 		func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 			err := handler(srv, &testInterceptServerStream{
 				ServerStream: ss,

--- a/server.go
+++ b/server.go
@@ -65,8 +65,8 @@ func (r HandlerMap) QueryService(name string) (*grpc.ServiceDesc, interface{}) {
 //    // Register all handlers once with the map:
 //    reg := channel.HandlerMap{}
 //    // (these registration functions are generated)
-//    foo.RegisterFooBarHandler(newFooBarImpl())
-//    fu.RegisterFuBazHandler(newFuBazImpl())
+//    foo.RegisterHandlerFooBar(newFooBarImpl())
+//    fu.RegisterHandlerFuBaz(newFuBazImpl())
 //
 //    // Now we can re-use these handlers for multiple channels:
 //    //   Normal gRPC


### PR DESCRIPTION
Reverts fullstorydev/grpchan#5

The new names conflict with methods generated by grpc-gateway. For now, rolling this back.

May roll it back in if I can land https://github.com/grpc-ecosystem/grpc-gateway/pull/571.