### PR TITLE
fix bug where trailer msg confused by client for a regular response msg

### DIFF
--- a/httpgrpc/httpgrpc_test.go
+++ b/httpgrpc/httpgrpc_test.go
@@ -2,10 +2,13 @@ package httpgrpc_test
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"testing"
+
+	"golang.org/x/net/context"
 
 	"github.com/fullstorydev/grpchan"
 	"github.com/fullstorydev/grpchan/grpchantesting"
@@ -39,4 +42,20 @@ func TestGrpcOverHttp(t *testing.T) {
 	}
 
 	grpchantesting.RunChannelTestCases(t, &cc, false)
+
+	t.Run("empty-trailer", func(t *testing.T) {
+		// test RPC w/ streaming response where trailer message is empty
+		// (e.g. no trailer metadata and code == 0 [OK])
+		cli := grpchantesting.NewTestServiceChannelClient(&cc)
+		str, err := cli.ServerStream(context.Background(), &grpchantesting.Message{})
+		if err != nil {
+			t.Fatalf("failed to initiate server stream: %v", err)
+		}
+		// if there is an issue with trailer message, it will appear to be
+		// a regular message and err would be nil
+		_, err = str.Recv()
+		if err != io.EOF {
+			t.Fatalf("server stream should not have returned any messages")
+		}
+	})
 }

--- a/httpgrpc/server.go
+++ b/httpgrpc/server.go
@@ -193,6 +193,13 @@ func HandleStream(svr interface{}, serviceName string, desc *grpc.StreamDesc, st
 			tr.Message = "Internal Server Error"
 		}
 
+		// must put something the trailing message so it's size is non-zero
+		// (otherwise, it's envelope cannot indicate a negative number, and
+		// it will be confused for a normal response message)
+		if tr.Message == "" {
+			tr.Message = codes.Code(tr.Code).String()
+		}
+
 		writeProtoMessage(w, &tr, true)
 	}
 }


### PR DESCRIPTION
I was trying to integrate changes in this repo into our mono-repo and luckily we had a test that caught this.

I added a test that repros the issue (fails w/out the changes to real code) and then added the fix. This was a regression introduced in #8 (right [here](https://github.com/fullstorydev/grpchan/pull/8/files#diff-aa73669c8b7bf9b64f925ac0e148b672L167)).