### PR TITLE
fix goroutine leak in inprocgrpc

### DIFF
--- a/inprocgrpc/in_process_test.go
+++ b/inprocgrpc/in_process_test.go
@@ -1,7 +1,9 @@
 package inprocgrpc_test
 
 import (
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/fullstorydev/grpchan/grpchantesting"
 	"github.com/fullstorydev/grpchan/inprocgrpc"
@@ -13,5 +15,20 @@ func TestInProcessChannel(t *testing.T) {
 	var cc inprocgrpc.Channel
 	grpchantesting.RegisterHandlerTestService(&cc, svr)
 
+	before := runtime.NumGoroutine()
+
 	grpchantesting.RunChannelTestCases(t, &cc, true)
+
+	// check for goroutine leaks
+	deadline := time.Now().Add(time.Second * 5)
+	after := 0
+	for deadline.After(time.Now()) {
+		after = runtime.NumGoroutine()
+		if after <= before {
+			// number of goroutines returned to previous level: no leak!
+			return
+		}
+		time.Sleep(time.Millisecond * 50)
+	}
+	t.Errorf("%d goroutines leaked", after-before)
 }


### PR DESCRIPTION
Adds a test that confirms that unary RPCs can leak goroutines when the RPC is cancelled or is deadline is exceeded. Adds a fix: writes to channel must use `select` operation to respect RPC context. Otherwise, channel write operation can block indefinitely (causing goroutine to leak) because there is nothing reading the channel.