### PR TITLE
only run static analyzers in 1.10 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ sudo: false
 
 matrix:
   include:
-    - go: 1.8
-    - go: 1.9
+    - go: "1.8"
+    - go: "1.9"
+    - go: "1.10"
+      env: VET=1
     - go: tip
 
 script:
-  - make
+  - if [[ "$VET" = 1 ]]; then make; else make deps test; fi


### PR DESCRIPTION
Some check tools (like `staticcheck`) have been recently updated so they do not work with older versions of Go. So we only run them once, with recent version of Go.