### PR TITLE
grpchantesting: prevent panic in bidi stream of test service

### DIFF
--- a/grpchantesting/test_service.go
+++ b/grpchantesting/test_service.go
@@ -155,9 +155,11 @@ func (s *TestServer) BidiStream(str TestService_BidiStreamServer) error {
 			}
 		}
 	}
-	str.SetTrailer(metadata.New(req.Trailers))
-	if req.Code != 0 {
-		return statusFromRequest(req)
+	if req != nil {
+		str.SetTrailer(metadata.New(req.Trailers))
+		if req.Code != 0 {
+			return statusFromRequest(req)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
The test service implementation of the bidi stream would panic (nil dereference) If it received no requests. This fixes it.