### PR TITLE
staticcheck no longer works with Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ matrix:
     - go: tip
 
 script:
-  - if [[ "$VET" = 1 ]]; then make; else make deps test; fi
+  - if [[ "$VET" = 1 ]]; then make ci; else make deps test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,15 @@ matrix:
   include:
     - go: "1.9"
     - go: "1.10"
-      env: VET=1
     - go: "1.11"
+      env:
+      - GO111MODULE=off
+      - VET=1
+    - go: "1.11"
+      env: GO111MODULE=on
+    - go: "1.12"
       env: GO111MODULE=off
-    - go: "1.11"
+    - go: "1.12"
       env: GO111MODULE=on
     - go: tip
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # they are just too noisy to be a requirement for a CI -- we don't even *want*
 # to fix some of the things they consider to be violations.
 .PHONY: ci
-ci: deps checkgofmt vet staticcheck unused ineffassign predeclared test
+ci: deps checkgofmt vet staticcheck ineffassign predeclared test
 
 .PHONY: deps
 deps:
@@ -33,11 +33,6 @@ vet:
 staticcheck:
 	@go get honnef.co/go/tools/cmd/staticcheck
 	staticcheck ./...
-
-.PHONY: unused
-unused:
-	@go get honnef.co/go/tools/cmd/unused
-	unused ./...
 
 .PHONY: ineffassign
 ineffassign:


### PR DESCRIPTION
Also removes `unused` target since that tool now reports itself as deprecated and superseded by `staticcheck`.