### PR TITLE
fix go.mod for Go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/fullstorydev/grpchan
 require (
 	github.com/golang/protobuf v1.3.1
 	github.com/jhump/gopoet v0.1.0
-	github.com/jhump/goprotoc v0.1.0
-	github.com/jhump/protoreflect v1.4.2
+	github.com/jhump/goprotoc v0.1.1
+	github.com/jhump/protoreflect v1.5.0
 	golang.org/x/net v0.0.0-20190522155817-f3200d17e092
-	google.golang.org/genproto v0.0.0-20170818100345-ee236bd376b0
+	google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0
 	google.golang.org/grpc v1.11.0
 )

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,10 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/jhump/gopoet v0.0.0-20190322174617-17282ff210b3/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/gopoet v0.1.0 h1:gYjOPnzHd2nzB37xYQZxj4EIQNpBrBskRqQQ3q4ZgSg=
 github.com/jhump/gopoet v0.1.0/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
-github.com/jhump/goprotoc v0.1.0 h1:91jyx8xXXQ+hOqgfpvahYqkirirzF5wOBrQNLoxdfFU=
-github.com/jhump/goprotoc v0.1.0/go.mod h1:T9qsgfpxsMCkLdsjXgZ9nm03BIbeTMN1tSSmXMJFWTM=
-github.com/jhump/protoreflect v1.4.2 h1:g5ljR1kXk0XM49b+BbRJmm9qhuQ5y3Va9rBZWkiLvgo=
-github.com/jhump/protoreflect v1.4.2/go.mod h1:gZ3i/BeD62fjlaIL0VW4UDMT70CTX+3m4pOnAlJ0BX8=
+github.com/jhump/goprotoc v0.1.1 h1:33RzcB79d8l39S28m+vXi26sXHBWAZTMyh6cWbVebUs=
+github.com/jhump/goprotoc v0.1.1/go.mod h1:TM0lulZUNujIC+aepfTnT5KK1gpI15BcON2TTVBsWzI=
+github.com/jhump/protoreflect v1.5.0 h1:NgpVT+dX71c8hZnxHof2M7QDK7QtohIJ7DYycjnkyfc=
+github.com/jhump/protoreflect v1.5.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092 h1:4QSRKanuywn15aTZvI/mIDEgPQpswuFndXpOj3rKEco=
@@ -15,8 +15,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-google.golang.org/genproto v0.0.0-20170818100345-ee236bd376b0 h1:jgaHBfsPDMBDKsth1hPtI1HcOyecWndWOFSGW21VgaM=
-google.golang.org/genproto v0.0.0-20170818100345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0 h1:ZvI3lsq5AIkr7axxmT3tfwFlJVRFLqe6Fp0W03+MJ38=
+google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.11.0 h1:jHfImns1/51jEDE5sWtuzn4vDPS2J9G+LbS5BCc6nM8=
 google.golang.org/grpc v1.11.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=


### PR DESCRIPTION
Somehow, the `go.mod` file in this repo (and in another related repo: jhump/protoreflect) had a timestamp incorrect. I don't know how that happened since I usually use the `go` tool (or copy+paste) to enter those git-hash-based versions into a file.

Anyhow, Go 1.13 does stronger verification, so this fails to build. (For example: https://travis-ci.org/fullstorydev/grpchan/jobs/568673714.)

This fixes it by:
1) Fixing the bad version (had hour 01 transposed as 10??).
2) Upgrading to a fixed version of protoreflect (same fix as bullet 1 had to be applied there, too)
3) Upgrading to a fixed version of goprotoc -- it had the problem indirectly via dependency on earlier (e.g. borked) version of protoreflect
