### PR TITLE
remove default case on parse arg

### DIFF
--- a/cmd/protoc-gen-grpchan/protoc-gen-grpchan.go
+++ b/cmd/protoc-gen-grpchan/protoc-gen-grpchan.go
@@ -192,8 +192,6 @@ func parseArgs(args []string) (codeGenArgs, error) {
 			default:
 				return result, fmt.Errorf("invalid boolean arg for option 'debug': %s", vals[1])
 			}
-		default:
-			return result, fmt.Errorf("unknown plugin argument: %s", vals[0])
 		}
 	}
 	return result, nil


### PR DESCRIPTION
After updating this to the new version, there is an issue using the `prototool`  : 
```
<input>:1:1:protoc-gen-grpchan: grpchan: unknown plugin argument: Mpath/to/proto/file.proto
```
the issue is the Mpath is required for the plugin, but this proto blocks it. 
