### PR TITLE
import map M... options override import_path option

### DIFF
--- a/cmd/protoc-gen-grpchan/protoc-gen-grpchan.go
+++ b/cmd/protoc-gen-grpchan/protoc-gen-grpchan.go
@@ -30,7 +30,11 @@ func doCodeGen(req *plugins.CodeGenRequest, resp *plugins.CodeGenResponse) error
 		// package for each file, which will cache the override name
 		// so all subsequent queries are consistent
 		for _, fd := range req.Files {
-			names.GoPackageForFileWithOverride(fd, args.importPath)
+			// Only use the override for files that don't otherwise have an
+			// entry in the specified import map
+			if _, ok := args.importMap[fd.GetName()]; !ok {
+				names.GoPackageForFileWithOverride(fd, args.importPath)
+			}
 		}
 	}
 	for _, fd := range req.Files {


### PR DESCRIPTION
In my last change, I got the order wrong. The code would use the `import_path` option, if specified, for every file being compiled. But the actual logic should let the `M...` mappings override that (based on the `protoc-gen-go` implementation [here](https://github.com/golang/protobuf/blob/347cf4a86c1cb8d262994d8ef5924d4576c5b331/protoc-gen-go/generator/generator.go#L736)).