### PR TITLE
drop Go 1.9 and 1.10; add Go 1.13 and Go 1.14; vet w/ modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,28 @@ sudo: false
 
 matrix:
   include:
-    - go: "1.9"
-    - go: "1.10"
-    - go: "1.11"
-      env:
-      - GO111MODULE=off
-      - VET=1
-    - go: "1.11"
-      env: GO111MODULE=on
-    - go: "1.12"
+    - go: "1.11.x"
       env: GO111MODULE=off
-    - go: "1.12"
+    - go: "1.11.x"
+      env:
+      - GO111MODULE=on
+      - VET=1
+    - go: "1.12.x"
+      env: GO111MODULE=off
+    - go: "1.12.x"
       env: GO111MODULE=on
+    - go: 1.13.x
+      env:
+      - GO111MODULE=on
+      - GOPROXY=direct
+    - go: 1.14.x
+      env:
+      - GO111MODULE=on
+      - GOPROXY=direct
     - go: tip
+      env:
+      - GO111MODULE=on
+      - GOPROXY=direct
 
 script:
   - if [[ "$VET" = 1 ]]; then make ci; else make deps test; fi


### PR DESCRIPTION
This fixes the static check stuff just like in the grpcurl and grpcui pull requests.

It also removes testing for Go 1.9 and Go 1.10 and adds testing for Go 1.13 and Go 1.14.