### PR TITLE
can't test on go 1.11 w/out modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: false
 matrix:
   include:
     - go: 1.11.x
-      env: GO111MODULE=off
-    - go: 1.11.x
       env: GO111MODULE=on
     - go: 1.12.x
       env: GO111MODULE=off


### PR DESCRIPTION
@dragonsinth, one more of these...

Latest [grpc-go module](https://github.com/grpc/grpc-go/pull/3767) no longer supports go 1.11. Since non-module builds in CI always gets latest of all deps, we can no longer support go 1.11 for non-module builds.

This will fix the current [build break](https://travis-ci.com/github/fullstorydev/grpchan/jobs/367087380).