### PR TITLE
add ability to customize HTTP error response for unary RPCs

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -1,6 +1,7 @@
 package grpchan
 
 import (
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 
@@ -8,7 +9,14 @@ import (
 // code, it can provide an alternate transport to the standard HTTP/2-based one.
 // For example, a Channel implementation could instead provide an HTTP 1.1-based
 // transport, or an in-process transport.
-type Channel = grpc.ClientConnInterface
+type Channel interface {
+	// InvokeUnary executes a unary RPC, sending the given req message and populating
+	// the given resp with the server's reply.
+	Invoke(ctx context.Context, methodName string, req, resp interface{}, opts ...grpc.CallOption) error
+
+	// InvokeStream executes a streaming RPC.
+	NewStream(ctx context.Context, desc *grpc.StreamDesc, methodName string, opts ...grpc.CallOption) (grpc.ClientStream, error)
+}
 
 // Channel interface matches the relevant methods on ClientConn
 var _ Channel = (*grpc.ClientConn)(nil)

--- a/channel.go
+++ b/channel.go
@@ -1,7 +1,6 @@
 package grpchan
 
 import (
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 
@@ -9,14 +8,7 @@ import (
 // code, it can provide an alternate transport to the standard HTTP/2-based one.
 // For example, a Channel implementation could instead provide an HTTP 1.1-based
 // transport, or an in-process transport.
-type Channel interface {
-	// InvokeUnary executes a unary RPC, sending the given req message and populating
-	// the given resp with the server's reply.
-	Invoke(ctx context.Context, methodName string, req, resp interface{}, opts ...grpc.CallOption) error
-
-	// InvokeStream executes a streaming RPC.
-	NewStream(ctx context.Context, desc *grpc.StreamDesc, methodName string, opts ...grpc.CallOption) (grpc.ClientStream, error)
-}
+type Channel = grpc.ClientConnInterface
 
 // Channel interface matches the relevant methods on ClientConn
 var _ Channel = (*grpc.ClientConn)(nil)

--- a/httpgrpc/codes.go
+++ b/httpgrpc/codes.go
@@ -17,7 +17,7 @@ func httpStatusFromCode(code codes.Code) int {
 	case codes.OK:
 		return http.StatusOK
 	case codes.Canceled:
-		return 499
+		return http.StatusBadGateway
 	case codes.Unknown:
 		return http.StatusInternalServerError
 	case codes.InvalidArgument:

--- a/httpgrpc/codes.go
+++ b/httpgrpc/codes.go
@@ -23,7 +23,7 @@ func httpStatusFromCode(code codes.Code) int {
 	case codes.InvalidArgument:
 		return http.StatusBadRequest
 	case codes.DeadlineExceeded:
-		return 499
+		return http.StatusGatewayTimeout
 	case codes.NotFound:
 		return http.StatusNotFound
 	case codes.AlreadyExists:

--- a/httpgrpc/codes.go
+++ b/httpgrpc/codes.go
@@ -6,7 +6,7 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-// HttpStatusFromCode translates the given GRPC code into an HTTP
+// httpStatusFromCode translates the given GRPC code into an HTTP
 // response. This is used to set the HTTP status code for unary RPCs.
 // (Streaming RPCs cannot convey a GRPC status code until the stream
 // completes, so they use a 200 HTTP status code and then encode the

--- a/httpgrpc/server.go
+++ b/httpgrpc/server.go
@@ -52,7 +52,7 @@ type handlerOpts struct {
 // the HTTP status code to use.
 //
 // If no such option is used the handler will use DefaultErrorRenderer.
-func ErrorRenderer(errFunc func(context.Context, *status.Status, http.Header) (httpCode int)) HandlerOption {
+func ErrorRenderer(errFunc func(reqCtx context.Context, st *status.Status, rspHdr http.Header) (httpCode int)) HandlerOption {
 	return func(h *handlerOpts) {
 		h.errFunc = errFunc
 	}


### PR DESCRIPTION
The provides a way for calling code to set a custom error renderer, to override the default mapping of gRPC errors to HTTP responses.

Since streams write the gRPC status into the body, as a trailing message, this is only for unary RPCs.

It also tweaks the existing mapping so that a `Cancelled` or `DeadlineExceeded` code only maps to 499 when the request context is cancelled. Otherwise, a 502 Bad Gateway or 504 Gateway Timeout status is used, respectively.