### PR TITLE
oof, major bug: infinite loop when trying to intercept an already-intercepted channel

### DIFF
--- a/intercept.go
+++ b/intercept.go
@@ -52,7 +52,7 @@ func unwrap(ch grpc.ClientConnInterface) grpc.ClientConnInterface {
 		if !ok {
 			return ch
 		}
-		ch = w
+		ch = w.Unwrap()
 	}
 }
 


### PR DESCRIPTION
If a call to `grpchan.InterceptClientConn` is made 2x, to wrap a channel with 2 (or more) layers of interceptors, then RPCs to the resulting channel will get stuck in an infinite loop to a bug in the code that tries to unwrap the interceptors to get down to the root `*grpc.ClientConn`.
🤦 