### PR TITLE
Chain interceptors

### DIFF
--- a/intercept.go
+++ b/intercept.go
@@ -301,7 +301,7 @@ func chainUnaryServer(unaryInt []grpc.UnaryServerInterceptor) grpc.UnaryServerIn
 				return currInterceptor(ctx, req, info, currHandler)
 			}
 		}
-		return unaryInt[0](ctx, req, info, handler)
+		return handler(ctx, req)
 	}
 }
 
@@ -317,6 +317,6 @@ func chainStreamServer(streamInt []grpc.StreamServerInterceptor) grpc.StreamServ
 				return currInterceptor(impl, stream, info, currHandler)
 			}
 		}
-		return streamInt[0](impl, stream, info, handler)
+		return handler(impl, stream)
 	}
 }

--- a/intercept.go
+++ b/intercept.go
@@ -25,14 +25,69 @@ func InterceptChannel(ch grpc.ClientConnInterface, unaryInt grpc.UnaryClientInte
 }
 
 // InterceptClientConn returns a new channel that intercepts RPCs with the given
-// interceptors. If both given interceptors are nil, returns ch. Otherwise, the
-// returned value will implement WrappedClientConn and its Unwrap() method will
-// return ch.
+// interceptors, which may be nil. If both given interceptors are nil, returns ch.
+// Otherwise, the returned value will implement WrappedClientConn and its Unwrap()
+// method will return ch.
 func InterceptClientConn(ch grpc.ClientConnInterface, unaryInt grpc.UnaryClientInterceptor, streamInt grpc.StreamClientInterceptor) grpc.ClientConnInterface {
-	if unaryInt == nil && streamInt == nil {
+	if unaryInt != nil {
+		ch = InterceptClientConnUnary(ch, unaryInt)
+	}
+	if streamInt != nil {
+		ch = InterceptClientConnStream(ch, streamInt)
+	}
+	return ch
+}
+
+// InterceptClientConnUnary returns a new channel that intercepts unary RPCs
+// with the given chain of interceptors. If the given set of interceptors is
+// empty, this returns ch. Otherwise, the returned value will implement
+// WrappedClientConn and its Unwrap() method will return ch.
+//
+// The first interceptor in the set will be the first one invoked when an RPC
+// is called. When that interceptor delegates to the provided invoker, it will
+// call the second interceptor, and so on.
+func InterceptClientConnUnary(ch grpc.ClientConnInterface, unaryInt ...grpc.UnaryClientInterceptor) grpc.ClientConnInterface {
+	if len(unaryInt) == 0 {
 		return ch
 	}
-	return &interceptedChannel{ch: ch, unaryInt: unaryInt, streamInt: streamInt}
+	var streamInt grpc.StreamClientInterceptor
+	intCh, ok := ch.(*interceptedChannel)
+	if ok {
+		// Instead of building a chain of multiple interceptedChannels, build
+		// a single interceptedChannel with the combined set of interceptors.
+		ch = intCh.ch
+		if intCh.unaryInt != nil {
+			unaryInt = append(unaryInt, intCh.unaryInt)
+		}
+		streamInt = intCh.streamInt
+	}
+	return &interceptedChannel{ch: ch, unaryInt: chainUnaryClient(unaryInt), streamInt: streamInt}
+}
+
+// InterceptClientConnStream returns a new channel that intercepts streaming
+// RPCs with the given chain of interceptors. If the given set of interceptors
+// is empty, this returns ch. Otherwise, the returned value will implement
+// WrappedClientConn and its Unwrap() method will return ch.
+//
+// The first interceptor in the set will be the first one invoked when an RPC
+// is called. When that interceptor delegates to the provided invoker, it will
+// call the second interceptor, and so on.
+func InterceptClientConnStream(ch grpc.ClientConnInterface, streamInt ...grpc.StreamClientInterceptor) grpc.ClientConnInterface {
+	if len(streamInt) == 0 {
+		return ch
+	}
+	var unaryInt grpc.UnaryClientInterceptor
+	intCh, ok := ch.(*interceptedChannel)
+	if ok {
+		// Instead of building a chain of multiple interceptedChannels, build
+		// a single interceptedChannel with the combined set of interceptors.
+		ch = intCh.ch
+		unaryInt = intCh.unaryInt
+		if intCh.streamInt != nil {
+			streamInt = append(streamInt, intCh.streamInt)
+		}
+	}
+	return &interceptedChannel{ch: ch, unaryInt: unaryInt, streamInt: chainStreamClient(streamInt)}
 }
 
 type interceptedChannel struct {
@@ -52,11 +107,15 @@ func unwrap(ch grpc.ClientConnInterface) grpc.ClientConnInterface {
 		if !ok {
 			return ch
 		}
-		ch = w.Unwrap()
+		unwrapped := w.Unwrap()
+		if unwrapped == nil {
+			return ch
+		}
+		ch = unwrapped
 	}
 }
 
-func (intch *interceptedChannel) Invoke(ctx context.Context, methodName string, req, resp interface{}, opts ...grpc.CallOption) error {
+func (intch *interceptedChannel) Invoke(ctx context.Context, methodName string, req, resp any, opts ...grpc.CallOption) error {
 	if intch.unaryInt == nil {
 		return intch.ch.Invoke(ctx, methodName, req, resp, opts...)
 	}
@@ -64,7 +123,7 @@ func (intch *interceptedChannel) Invoke(ctx context.Context, methodName string, 
 	return intch.unaryInt(ctx, methodName, req, resp, cc, intch.unaryInvoker, opts...)
 }
 
-func (intch *interceptedChannel) unaryInvoker(ctx context.Context, methodName string, req, resp interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+func (intch *interceptedChannel) unaryInvoker(ctx context.Context, methodName string, req, resp any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 	return intch.ch.Invoke(ctx, methodName, req, resp, opts...)
 }
 
@@ -80,24 +139,97 @@ func (intch *interceptedChannel) streamer(ctx context.Context, desc *grpc.Stream
 	return intch.ch.NewStream(ctx, desc, methodName, opts...)
 }
 
-var _ Channel = (*interceptedChannel)(nil)
+var _ grpc.ClientConnInterface = (*interceptedChannel)(nil)
 
-// WithInterceptor returns a view of the given ServiceRegistry that will
+func chainUnaryClient(unaryInt []grpc.UnaryClientInterceptor) grpc.UnaryClientInterceptor {
+	if len(unaryInt) == 1 {
+		return unaryInt[0]
+	}
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		for i := range unaryInt {
+			currInterceptor := unaryInt[len(unaryInt)-i-1] // going backwards through the chain
+			currInvoker := invoker
+			invoker = func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+				return currInterceptor(ctx, method, req, reply, cc, currInvoker, opts...)
+			}
+		}
+		return unaryInt[0](ctx, method, req, reply, cc, invoker, opts...)
+	}
+}
+
+func chainStreamClient(streamInt []grpc.StreamClientInterceptor) grpc.StreamClientInterceptor {
+	if len(streamInt) == 1 {
+		return streamInt[0]
+	}
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		for i := range streamInt {
+			currInterceptor := streamInt[len(streamInt)-i-1] // going backwards through the chain
+			currStreamer := streamer
+			streamer = func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+				return currInterceptor(ctx, desc, cc, method, currStreamer, opts...)
+			}
+		}
+		return streamInt[0](ctx, desc, cc, method, streamer, opts...)
+	}
+}
+
+// WithInterceptor returns a view of the given ServiceRegistrar that will
 // automatically apply the given interceptors to all registered services.
-func WithInterceptor(reg ServiceRegistry, unaryInt grpc.UnaryServerInterceptor, streamInt grpc.StreamServerInterceptor) ServiceRegistry {
-	if unaryInt == nil && streamInt == nil {
+func WithInterceptor(reg grpc.ServiceRegistrar, unaryInt grpc.UnaryServerInterceptor, streamInt grpc.StreamServerInterceptor) grpc.ServiceRegistrar {
+	if unaryInt != nil {
+		reg = WithUnaryInterceptors(reg, unaryInt)
+	}
+	if streamInt != nil {
+		reg = WithStreamInterceptors(reg, streamInt)
+	}
+	return reg
+}
+
+// WithUnaryInterceptors returns a view of the given ServiceRegistrar that will
+// automatically apply the given interceptors to all registered services.
+func WithUnaryInterceptors(reg grpc.ServiceRegistrar, unaryInt ...grpc.UnaryServerInterceptor) grpc.ServiceRegistrar {
+	if len(unaryInt) == 0 {
 		return reg
 	}
-	return &interceptingRegistry{reg: reg, unaryInt: unaryInt, streamInt: streamInt}
+	var streamInt grpc.StreamServerInterceptor
+	intReg, ok := reg.(*interceptingRegistry)
+	if ok {
+		// Instead of building a chain of multiple interceptingRegistry instances,
+		// build a single interceptingRegistry with the combined set of interceptors.
+		reg = intReg.reg
+		if intReg.unaryInt != nil {
+			unaryInt = append(unaryInt, intReg.unaryInt)
+		}
+		streamInt = intReg.streamInt
+	}
+	return &interceptingRegistry{reg: reg, unaryInt: chainUnaryServer(unaryInt), streamInt: streamInt}
+}
+
+func WithStreamInterceptors(reg grpc.ServiceRegistrar, streamInt ...grpc.StreamServerInterceptor) grpc.ServiceRegistrar {
+	if len(streamInt) == 0 {
+		return reg
+	}
+	var unaryInt grpc.UnaryServerInterceptor
+	intReg, ok := reg.(*interceptingRegistry)
+	if ok {
+		// Instead of building a chain of multiple interceptingRegistry instances,
+		// build a single interceptingRegistry with the combined set of interceptors.
+		reg = intReg.reg
+		unaryInt = intReg.unaryInt
+		if intReg.streamInt != nil {
+			streamInt = append(streamInt, intReg.streamInt)
+		}
+	}
+	return &interceptingRegistry{reg: reg, unaryInt: unaryInt, streamInt: chainStreamServer(streamInt)}
 }
 
 type interceptingRegistry struct {
-	reg       ServiceRegistry
+	reg       grpc.ServiceRegistrar
 	unaryInt  grpc.UnaryServerInterceptor
 	streamInt grpc.StreamServerInterceptor
 }
 
-func (r *interceptingRegistry) RegisterService(desc *grpc.ServiceDesc, srv interface{}) {
+func (r *interceptingRegistry) RegisterService(desc *grpc.ServiceDesc, srv any) {
 	r.reg.RegisterService(InterceptServer(desc, r.unaryInt, r.streamInt), srv)
 }
 
@@ -116,12 +248,12 @@ func InterceptServer(svcDesc *grpc.ServiceDesc, unaryInt grpc.UnaryServerInterce
 			origHandler := md.Handler
 			intercepted.Methods[i] = grpc.MethodDesc{
 				MethodName: md.MethodName,
-				Handler: func(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+				Handler: func(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 					combinedInterceptor := unaryInt
 					if interceptor != nil {
 						// combine unaryInt with the interceptor provided to handler
-						combinedInterceptor = func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
-							h := func(ctx context.Context, req interface{}) (interface{}, error) {
+						combinedInterceptor = func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+							h := func(ctx context.Context, req any) (any, error) {
 								return unaryInt(ctx, req, info, handler)
 							}
 							// we first call provided interceptor, but supply a handler that will call unaryInt
@@ -147,7 +279,7 @@ func InterceptServer(svcDesc *grpc.ServiceDesc, unaryInt grpc.UnaryServerInterce
 				StreamName:    sd.StreamName,
 				ClientStreams: sd.ClientStreams,
 				ServerStreams: sd.ServerStreams,
-				Handler: func(srv interface{}, stream grpc.ServerStream) error {
+				Handler: func(srv any, stream grpc.ServerStream) error {
 					return streamInt(srv, stream, info, origHandler)
 				},
 			}
@@ -155,4 +287,36 @@ func InterceptServer(svcDesc *grpc.ServiceDesc, unaryInt grpc.UnaryServerInterce
 	}
 
 	return &intercepted
+}
+
+func chainUnaryServer(unaryInt []grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
+	if len(unaryInt) == 1 {
+		return unaryInt[0]
+	}
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		for i := range unaryInt {
+			currInterceptor := unaryInt[len(unaryInt)-i-1] // going backwards through the chain
+			currHandler := handler
+			handler = func(ctx context.Context, req any) (any, error) {
+				return currInterceptor(ctx, req, info, currHandler)
+			}
+		}
+		return unaryInt[0](ctx, req, info, handler)
+	}
+}
+
+func chainStreamServer(streamInt []grpc.StreamServerInterceptor) grpc.StreamServerInterceptor {
+	if len(streamInt) == 1 {
+		return streamInt[0]
+	}
+	return func(impl any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		for i := range streamInt {
+			currInterceptor := streamInt[len(streamInt)-i-1] // going backwards through the chain
+			currHandler := handler
+			handler = func(impl any, stream grpc.ServerStream) error {
+				return currInterceptor(impl, stream, info, currHandler)
+			}
+		}
+		return streamInt[0](impl, stream, info, handler)
+	}
 }

--- a/intercept.go
+++ b/intercept.go
@@ -153,7 +153,7 @@ func chainUnaryClient(unaryInt []grpc.UnaryClientInterceptor) grpc.UnaryClientIn
 				return currInterceptor(ctx, method, req, reply, cc, currInvoker, opts...)
 			}
 		}
-		return unaryInt[0](ctx, method, req, reply, cc, invoker, opts...)
+		return invoker(ctx, method, req, reply, cc, opts...)
 	}
 }
 
@@ -169,7 +169,7 @@ func chainStreamClient(streamInt []grpc.StreamClientInterceptor) grpc.StreamClie
 				return currInterceptor(ctx, desc, cc, method, currStreamer, opts...)
 			}
 		}
-		return streamInt[0](ctx, desc, cc, method, streamer, opts...)
+		return streamer(ctx, desc, cc, method, opts...)
 	}
 }
 

--- a/intercept_server_test.go
+++ b/intercept_server_test.go
@@ -3,7 +3,6 @@ package grpchan_test
 import (
 	"context"
 	"fmt"
-	"github.com/golang/protobuf/ptypes/empty"
 	"io"
 	"reflect"
 	"testing"
@@ -368,7 +367,7 @@ func (s *testServer) BidiStream(stream grpchantesting.TestService_BidiStreamServ
 	}, nil, stream)
 }
 
-func (s *testServer) UseExternalMessageTwice(ctx context.Context, req *emptypb.Empty) (*empty.Empty, error) {
+func (s *testServer) UseExternalMessageTwice(ctx context.Context, req *emptypb.Empty) (*emptypb.Empty, error) {
 	resp := emptypb.Empty{}
 	err := s.unary(ctx, "UseExternalMessageTwice", req, &resp)
 	if err != nil {

--- a/interceptor_chain_client_test.go
+++ b/interceptor_chain_client_test.go
@@ -1,0 +1,461 @@
+package grpchan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/fullstorydev/grpchan/internal"
+)
+
+var interceptorChainCases = []struct {
+	name              string
+	setupClient       func(grpc.ClientConnInterface) grpc.ClientConnInterface
+	setupServer       func(grpc.ServiceRegistrar) grpc.ServiceRegistrar
+	unaryIntercepted  bool
+	streamIntercepted bool
+}{
+	{
+		name: "batch",
+		setupClient: func(conn grpc.ClientConnInterface) grpc.ClientConnInterface {
+			return setupClientChainBatch(conn)
+		},
+		unaryIntercepted:  true,
+		streamIntercepted: true,
+	},
+	{
+		name: "singles",
+		setupClient: func(conn grpc.ClientConnInterface) grpc.ClientConnInterface {
+			return setupClientChainSingles(conn)
+		},
+		unaryIntercepted:  true,
+		streamIntercepted: true,
+	},
+	{
+		name: "pairs",
+		setupClient: func(conn grpc.ClientConnInterface) grpc.ClientConnInterface {
+			return setupClientChainPairs(conn)
+		},
+		unaryIntercepted:  true,
+		streamIntercepted: true,
+	},
+	{
+		name: "unary-only",
+		setupClient: func(conn grpc.ClientConnInterface) grpc.ClientConnInterface {
+			return setupClientChainUnaryOnly(conn)
+		},
+		unaryIntercepted:  true,
+		streamIntercepted: false,
+	},
+	{
+		name: "stream-only",
+		setupClient: func(conn grpc.ClientConnInterface) grpc.ClientConnInterface {
+			return setupClientChainStreamOnly(conn)
+		},
+		unaryIntercepted:  false,
+		streamIntercepted: true,
+	},
+	{
+		name: "none",
+		setupClient: func(conn grpc.ClientConnInterface) grpc.ClientConnInterface {
+			return conn
+		},
+		unaryIntercepted:  false,
+		streamIntercepted: false,
+	},
+}
+
+func TestInterceptorChainClient_Unary(t *testing.T) {
+	for _, testCase := range interceptorChainCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+			tc := testChainConn{t: t}
+			intercepted := testCase.setupClient(&tc)
+			var req, expectReply string
+			var expectHeaders, expectTrailers metadata.MD
+			if testCase.unaryIntercepted {
+				req = "req"
+				ctx = metadata.AppendToOutgoingContext(ctx, "header", "value")
+				expectHeaders = metadata.Pairs("header", "value", "header-A", "value-A", "header-B", "value-B", "header-C", "value-C")
+				expectTrailers = metadata.Pairs("trailer", "value", "trailer-A", "value-A", "trailer-B", "value-B", "trailer-C", "value-C")
+				expectReply = "reply,C,B,A"
+			} else {
+				// Need to add stuff to the request and headers, etc that would otherwise be added by
+				// interceptors for the test channel to be happy.
+				req = "req,A,B,C"
+				ctx = metadata.AppendToOutgoingContext(ctx, "header", "value", "header-A", "value-A", "header-B", "value-B", "header-C", "value-C")
+				// And we don't expect anything to be added to the response stuff.
+				expectHeaders = metadata.Pairs("header", "value")
+				expectTrailers = metadata.Pairs("trailer", "value")
+				expectReply = "reply"
+			}
+			var reply string
+			var headers, trailers metadata.MD
+			if err := intercepted.Invoke(ctx, "/foo/bar", req, &reply, grpc.Header(&headers), grpc.Trailer(&trailers)); err != nil {
+				t.Errorf("unexpected RPC error: %v", err)
+			} else if reply != expectReply {
+				t.Errorf("unexpected reply: %s", reply)
+			}
+			if !reflect.DeepEqual(expectHeaders, headers) {
+				t.Errorf("unexpected headers: %s", headers)
+			}
+			if !reflect.DeepEqual(expectTrailers, trailers) {
+				t.Errorf("unexpected trailers: %s", trailers)
+			}
+		})
+	}
+}
+
+func TestInterceptorChainClient_Stream(t *testing.T) {
+	for _, testCase := range interceptorChainCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+			tc := testChainConn{t: t}
+			intercepted := testCase.setupClient(&tc)
+			var reqSuffix, expectReplySuffix string
+			var expectHeaders, expectTrailers metadata.MD
+			if testCase.streamIntercepted {
+				reqSuffix = ""
+				ctx = metadata.AppendToOutgoingContext(ctx, "header", "value")
+				expectHeaders = metadata.Pairs("header", "value", "header-A", "value-A", "header-B", "value-B", "header-C", "value-C")
+				expectTrailers = metadata.Pairs("trailer", "value", "trailer-A", "value-A", "trailer-B", "value-B", "trailer-C", "value-C")
+				expectReplySuffix = ",C,B,A"
+			} else {
+				// Need to add stuff to the request and headers, etc that would otherwise be added by
+				// interceptors for the test channel to be happy.
+				reqSuffix = ",A,B,C"
+				ctx = metadata.AppendToOutgoingContext(ctx, "header", "value", "header-A", "value-A", "header-B", "value-B", "header-C", "value-C")
+				// And we don't expect anything to be added to the response stuff.
+				expectHeaders = metadata.Pairs("header", "value")
+				expectTrailers = metadata.Pairs("trailer", "value")
+				expectReplySuffix = ""
+			}
+
+			desc := &grpc.StreamDesc{StreamName: "bar", ClientStreams: true, ServerStreams: true}
+			stream, err := intercepted.NewStream(ctx, desc, "/foo/bar")
+			if err != nil {
+				t.Errorf("unexpected RPC error: %v", err)
+			}
+			if err := stream.SendMsg("req1" + reqSuffix); err != nil {
+				t.Errorf("unexpected RPC error: %v", err)
+			}
+			if err := stream.SendMsg("req2" + reqSuffix); err != nil {
+				t.Errorf("unexpected RPC error: %v", err)
+			}
+			if err := stream.SendMsg("req3" + reqSuffix); err != nil {
+				t.Errorf("unexpected RPC error: %v", err)
+			}
+			if err := stream.CloseSend(); err != nil {
+				t.Errorf("unexpected RPC error: %v", err)
+			}
+
+			var reply string
+			if err := stream.RecvMsg(&reply); err != nil {
+				t.Errorf("unexpected RPC error: %v", err)
+			}
+			if reply != "reply3"+expectReplySuffix {
+				t.Errorf("unexpected reply: %s", reply)
+			}
+			if err := stream.RecvMsg(&reply); err != nil {
+				t.Errorf("unexpected RPC error: %v", err)
+			}
+			if reply != "reply2"+expectReplySuffix {
+				t.Errorf("unexpected reply: %s", reply)
+			}
+			if err := stream.RecvMsg(&reply); err != nil {
+				t.Errorf("unexpected RPC error: %v", err)
+			}
+			if reply != "reply1"+expectReplySuffix {
+				t.Errorf("unexpected reply: %s", reply)
+			}
+			if err := stream.RecvMsg(&reply); err == nil {
+				t.Error("expecting io.EOF but got no error")
+			} else if !errors.Is(err, io.EOF) {
+				t.Errorf("expecting io.EOF but got %v", err)
+			}
+
+			headers, err := stream.Header()
+			if err != nil {
+				t.Errorf("unexpected RPC error: %v", err)
+			}
+			if !reflect.DeepEqual(expectHeaders, headers) {
+				t.Errorf("unexpected headers: %s", headers)
+			}
+			trailers := stream.Trailer()
+			if !reflect.DeepEqual(expectTrailers, trailers) {
+				t.Errorf("unexpected trailers: %s", trailers)
+			}
+		})
+	}
+}
+
+func setupClientChainBatch(clientConn grpc.ClientConnInterface) grpc.ClientConnInterface {
+	int1 := chainClientInterceptor{id: "A"}
+	int2 := chainClientInterceptor{id: "B"}
+	int3 := chainClientInterceptor{id: "C"}
+	return InterceptClientConnUnary(
+		InterceptClientConnStream(
+			clientConn,
+			int1.doStream, int2.doStream, int3.doStream,
+		),
+		int1.doUnary, int2.doUnary, int3.doUnary,
+	)
+}
+
+func setupClientChainSingles(clientConn grpc.ClientConnInterface) grpc.ClientConnInterface {
+	int1 := chainClientInterceptor{id: "A"}
+	int2 := chainClientInterceptor{id: "B"}
+	int3 := chainClientInterceptor{id: "C"}
+	return InterceptClientConnStream(
+		InterceptClientConnUnary(
+			InterceptClientConnStream(
+				InterceptClientConnUnary(
+					InterceptClientConnStream(
+						InterceptClientConnUnary(
+							clientConn,
+							int3.doUnary,
+						),
+						int3.doStream,
+					),
+					int2.doUnary,
+				),
+				int2.doStream,
+			),
+			int1.doUnary,
+		),
+		int1.doStream,
+	)
+}
+
+func setupClientChainPairs(clientConn grpc.ClientConnInterface) grpc.ClientConnInterface {
+	int1 := chainClientInterceptor{id: "A"}
+	int2 := chainClientInterceptor{id: "B"}
+	int3 := chainClientInterceptor{id: "C"}
+	return InterceptClientConn(
+		InterceptClientConn(
+			InterceptClientConn(
+				clientConn,
+				int3.doUnary, int3.doStream,
+			),
+			int2.doUnary, int2.doStream,
+		),
+		int1.doUnary, int1.doStream,
+	)
+}
+
+func setupClientChainUnaryOnly(clientConn grpc.ClientConnInterface) grpc.ClientConnInterface {
+	int1 := chainClientInterceptor{id: "A"}
+	int2 := chainClientInterceptor{id: "B"}
+	int3 := chainClientInterceptor{id: "C"}
+	return InterceptClientConnUnary(
+		InterceptClientConnUnary(
+			InterceptClientConnUnary(
+				clientConn,
+				int3.doUnary,
+			),
+			int2.doUnary,
+		),
+		int1.doUnary,
+	)
+}
+
+func setupClientChainStreamOnly(clientConn grpc.ClientConnInterface) grpc.ClientConnInterface {
+	int1 := chainClientInterceptor{id: "A"}
+	int2 := chainClientInterceptor{id: "B"}
+	int3 := chainClientInterceptor{id: "C"}
+	return InterceptClientConnStream(
+		InterceptClientConnStream(
+			InterceptClientConnStream(
+				clientConn,
+				int3.doStream,
+			),
+			int2.doStream,
+		),
+		int1.doStream,
+	)
+}
+
+type chainClientInterceptor struct {
+	id string
+}
+
+func (c *chainClientInterceptor) doUnary(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	ctx = metadata.AppendToOutgoingContext(ctx, "header-"+c.id, "value-"+c.id)
+	str, ok := req.(string)
+	if !ok {
+		return status.Errorf(codes.Internal, "unexpected request type: %T", req)
+	}
+	str += "," + c.id
+	strPtr, ok := reply.(*string)
+	if !ok {
+		return status.Errorf(codes.Internal, "unexpected response type: %T", reply)
+	}
+	var headers, trailers metadata.MD
+	opts = append(opts, grpc.Header(&headers), grpc.Trailer(&trailers))
+	if err := invoker(ctx, method, str, strPtr, cc, opts...); err != nil {
+		return err
+	}
+	if headers == nil {
+		return errors.New("response headers are nil")
+	}
+	headers.Append("header-"+c.id, "value-"+c.id)
+	if trailers == nil {
+		return errors.New("response trailers are nil")
+	}
+	trailers.Append("trailer-"+c.id, "value-"+c.id)
+	*strPtr += "," + c.id
+	return nil
+}
+
+func (c *chainClientInterceptor) doStream(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	ctx = metadata.AppendToOutgoingContext(ctx, "header-"+c.id, "value-"+c.id)
+	stream, err := streamer(ctx, desc, cc, method, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &chainClientStream{ClientStream: stream, id: c.id}, nil
+}
+
+type chainClientStream struct {
+	grpc.ClientStream
+	id string
+}
+
+func (c *chainClientStream) Header() (metadata.MD, error) {
+	md, err := c.ClientStream.Header()
+	if err != nil {
+		return nil, err
+	}
+	if md == nil {
+		return nil, errors.New("response header is nil")
+	}
+	md.Append("header-"+c.id, "value-"+c.id)
+	return md, nil
+}
+
+func (c *chainClientStream) Trailer() metadata.MD {
+	md := c.ClientStream.Trailer()
+	if md != nil {
+		md.Append("trailer-"+c.id, "value-"+c.id)
+	}
+	return md
+}
+
+func (c *chainClientStream) SendMsg(msg any) error {
+	str, ok := msg.(string)
+	if !ok {
+		return status.Errorf(codes.Internal, "unexpected message type: %T", msg)
+	}
+	str += "," + c.id
+	return c.ClientStream.SendMsg(str)
+}
+
+func (c *chainClientStream) RecvMsg(msg any) error {
+	str, ok := msg.(*string)
+	if !ok {
+		return status.Errorf(codes.Internal, "unexpected message type: %T", msg)
+	}
+	if err := c.ClientStream.RecvMsg(str); err != nil {
+		return err
+	}
+	*str += "," + c.id
+	return nil
+}
+
+type testChainConn struct {
+	t *testing.T
+}
+
+func (t *testChainConn) Invoke(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error {
+	if method != "/foo/bar" {
+		return fmt.Errorf("unexpected method: %s", method)
+	}
+	str, ok := args.(string)
+	if !ok {
+		return fmt.Errorf("invalid request: %T", args)
+	}
+	if str != "req,A,B,C" {
+		t.t.Errorf("unexpected request: %s", str)
+	}
+	headers, _ := metadata.FromOutgoingContext(ctx)
+	expectHeaders := metadata.Pairs("header", "value", "header-A", "value-A", "header-B", "value-B", "header-C", "value-C")
+	if !reflect.DeepEqual(expectHeaders, headers) {
+		t.t.Errorf("unexpected headers: %s", headers)
+	}
+	strPtr, ok := reply.(*string)
+	if !ok {
+		return fmt.Errorf("invalid response: %T", args)
+	}
+	*strPtr = "reply"
+	callOpts := internal.GetCallOptions(opts)
+	callOpts.SetHeaders(metadata.Pairs("header", "value"))
+	callOpts.SetTrailers(metadata.Pairs("trailer", "value"))
+	return nil
+}
+
+func (t *testChainConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return &testChainStreamClient{t: t.t, ctx: ctx}, nil
+}
+
+type testChainStreamClient struct {
+	t     *testing.T
+	ctx   context.Context
+	count int
+	done  bool
+}
+
+func (t *testChainStreamClient) Header() (metadata.MD, error) {
+	return metadata.Pairs("header", "value"), nil
+}
+
+func (t *testChainStreamClient) Trailer() metadata.MD {
+	return metadata.Pairs("trailer", "value")
+}
+
+func (t *testChainStreamClient) CloseSend() error {
+	t.done = true
+	return nil
+}
+
+func (t *testChainStreamClient) Context() context.Context {
+	return t.ctx
+}
+
+func (t *testChainStreamClient) SendMsg(m any) error {
+	if t.done {
+		return io.EOF
+	}
+	t.count++
+	str, ok := m.(string)
+	if !ok {
+		return fmt.Errorf("invalid message: %T", m)
+	}
+	if str != "req"+strconv.Itoa(t.count)+",A,B,C" {
+		t.t.Errorf("unexpected request: %s", str)
+	}
+	return nil
+
+}
+
+func (t *testChainStreamClient) RecvMsg(m any) error {
+	if t.count == 0 {
+		t.done = true
+		return io.EOF
+	}
+	str, ok := m.(*string)
+	if !ok {
+		return fmt.Errorf("invalid message: %T", m)
+	}
+	*str = "reply" + strconv.Itoa(t.count)
+	t.count--
+	return nil
+}

--- a/interceptor_chain_server_test.go
+++ b/interceptor_chain_server_test.go
@@ -1,0 +1,453 @@
+package grpchan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/fullstorydev/grpchan/internal"
+)
+
+func TestInterceptorChainServer_Unary(t *testing.T) {
+	for _, testCase := range interceptorChainCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+			handlers := HandlerMap{}
+			intercepted := testCase.setupServer(handlers)
+			th := testChainHandler{t: t}
+			intercepted.RegisterService(th.serviceDesc(), 0)
+			var req, expectReply string
+			var expectHeaders, expectTrailers metadata.MD
+			if testCase.unaryIntercepted {
+				req = "req"
+				ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("header", "value"))
+				expectHeaders = metadata.Pairs("header", "value", "header-A", "value-A", "header-B", "value-B", "header-C", "value-C")
+				expectTrailers = metadata.Pairs("trailer", "value", "trailer-A", "value-A", "trailer-B", "value-B", "trailer-C", "value-C")
+				expectReply = "reply,C,B,A"
+			} else {
+				// Need to add stuff to the request and headers, etc that would otherwise be added by
+				// interceptors for the test channel to be happy.
+				req = "req,A,B,C"
+				ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("header", "value", "header-A", "value-A", "header-B", "value-B", "header-C", "value-C"))
+				// And we don't expect anything to be added to the response stuff.
+				expectHeaders = metadata.Pairs("header", "value")
+				expectTrailers = metadata.Pairs("trailer", "value")
+				expectReply = "reply"
+			}
+			var reply string
+			dec := func(reqPtr any) error {
+				str, ok := reqPtr.(*string)
+				if !ok {
+					t.Errorf("invalid request type: %T", reqPtr)
+				}
+				*str = req
+				return nil
+			}
+			var stream testChainStreamServer
+			sts := &internal.ServerTransportStream{Name: "/foo/bar", Stream: &stream}
+			sd, srv := handlers.QueryService("foo")
+			resp, err := sd.Methods[0].Handler(srv, grpc.NewContextWithServerTransportStream(ctx, sts), dec, nil)
+			if err != nil {
+				t.Fatalf("unexpected RPC error: %v", err)
+			}
+			reply, ok := resp.(string)
+			if !ok {
+				t.Errorf("invalid reply type: %T", resp)
+			} else if reply != expectReply {
+				t.Errorf("unexpected reply: %s", reply)
+			}
+			if !reflect.DeepEqual(expectHeaders, stream.headers) {
+				t.Errorf("unexpected headers: %s", stream.headers)
+			}
+			if !reflect.DeepEqual(expectTrailers, stream.trailers) {
+				t.Errorf("unexpected trailers: %s", stream.trailers)
+			}
+		})
+	}
+}
+
+func TestInterceptorChainServer_Stream(t *testing.T) {
+	for _, testCase := range interceptorChainCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+			handlers := HandlerMap{}
+			intercepted := testCase.setupServer(handlers)
+			th := testChainHandler{t: t}
+			intercepted.RegisterService(th.serviceDesc(), 0)
+			var reqSuffix, expectReplySuffix string
+			var expectHeaders, expectTrailers metadata.MD
+			if testCase.streamIntercepted {
+				reqSuffix = ""
+				ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("header", "value"))
+				expectHeaders = metadata.Pairs("header", "value", "header-A", "value-A", "header-B", "value-B", "header-C", "value-C")
+				expectTrailers = metadata.Pairs("trailer", "value", "trailer-A", "value-A", "trailer-B", "value-B", "trailer-C", "value-C")
+				expectReplySuffix = ",C,B,A"
+			} else {
+				// Need to add stuff to the request and headers, etc that would otherwise be added by
+				// interceptors for the test channel to be happy.
+				reqSuffix = ",A,B,C"
+				ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("header", "value", "header-A", "value-A", "header-B", "value-B", "header-C", "value-C"))
+				// And we don't expect anything to be added to the response stuff.
+				expectHeaders = metadata.Pairs("header", "value")
+				expectTrailers = metadata.Pairs("trailer", "value")
+				expectReplySuffix = ""
+			}
+			sd, srv := handlers.QueryService("foo")
+			stream := &testChainStreamServer{
+				t:         t,
+				ctx:       ctx,
+				reqSuffix: reqSuffix,
+			}
+			err := sd.Streams[0].Handler(srv, stream)
+			if err != nil {
+				t.Fatalf("unexpected RPC error: %v", err)
+			}
+			expectedSent := []string{
+				"reply3" + expectReplySuffix,
+				"reply2" + expectReplySuffix,
+				"reply1" + expectReplySuffix,
+			}
+			if !reflect.DeepEqual(expectedSent, stream.sent) {
+				t.Errorf("unexpected sent: %s", stream.sent)
+			}
+			if !reflect.DeepEqual(expectHeaders, stream.headers) {
+				t.Errorf("unexpected headers: %s", stream.headers)
+			}
+			if !reflect.DeepEqual(expectTrailers, stream.trailers) {
+				t.Errorf("unexpected trailers: %s", stream.trailers)
+			}
+		})
+	}
+}
+
+func setupServerChainBatch(reg grpc.ServiceRegistrar) grpc.ServiceRegistrar {
+	int1 := chainServerInterceptor{id: "A"}
+	int2 := chainServerInterceptor{id: "B"}
+	int3 := chainServerInterceptor{id: "C"}
+	return WithUnaryInterceptors(
+		WithStreamInterceptors(
+			reg,
+			int1.doStream, int2.doStream, int3.doStream,
+		),
+		int1.doUnary, int2.doUnary, int3.doUnary,
+	)
+}
+
+func setupServerChainSingles(reg grpc.ServiceRegistrar) grpc.ServiceRegistrar {
+	int1 := chainServerInterceptor{id: "A"}
+	int2 := chainServerInterceptor{id: "B"}
+	int3 := chainServerInterceptor{id: "C"}
+	return WithStreamInterceptors(
+		WithUnaryInterceptors(
+			WithStreamInterceptors(
+				WithUnaryInterceptors(
+					WithStreamInterceptors(
+						WithUnaryInterceptors(
+							reg,
+							int3.doUnary,
+						),
+						int3.doStream,
+					),
+					int2.doUnary,
+				),
+				int2.doStream,
+			),
+			int1.doUnary,
+		),
+		int1.doStream,
+	)
+}
+
+func setupServerChainPairs(reg grpc.ServiceRegistrar) grpc.ServiceRegistrar {
+	int1 := chainServerInterceptor{id: "A"}
+	int2 := chainServerInterceptor{id: "B"}
+	int3 := chainServerInterceptor{id: "C"}
+	return WithInterceptor(
+		WithInterceptor(
+			WithInterceptor(
+				reg,
+				int3.doUnary, int3.doStream,
+			),
+			int2.doUnary, int2.doStream,
+		),
+		int1.doUnary, int1.doStream,
+	)
+}
+
+func setupServerChainUnaryOnly(reg grpc.ServiceRegistrar) grpc.ServiceRegistrar {
+	int1 := chainServerInterceptor{id: "A"}
+	int2 := chainServerInterceptor{id: "B"}
+	int3 := chainServerInterceptor{id: "C"}
+	return WithUnaryInterceptors(
+		WithUnaryInterceptors(
+			WithUnaryInterceptors(
+				reg,
+				int3.doUnary,
+			),
+			int2.doUnary,
+		),
+		int1.doUnary,
+	)
+}
+
+func setupServerChainStreamOnly(reg grpc.ServiceRegistrar) grpc.ServiceRegistrar {
+	int1 := chainServerInterceptor{id: "A"}
+	int2 := chainServerInterceptor{id: "B"}
+	int3 := chainServerInterceptor{id: "C"}
+	return WithStreamInterceptors(
+		WithStreamInterceptors(
+			WithStreamInterceptors(
+				reg,
+				int3.doStream,
+			),
+			int2.doStream,
+		),
+		int1.doStream,
+	)
+}
+
+type chainServerInterceptor struct {
+	id string
+}
+
+func (c *chainServerInterceptor) doUnary(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		md.Append("header-"+c.id, "value-"+c.id)
+		ctx = metadata.NewIncomingContext(ctx, md)
+	}
+	str, ok := req.(string)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "unexpected request type: %T", req)
+	}
+	str += "," + c.id
+	if err := grpc.SetHeader(ctx, metadata.Pairs("header-"+c.id, "value-"+c.id)); err != nil {
+		return nil, err
+	}
+	if grpc.SetTrailer(ctx, metadata.Pairs("trailer-"+c.id, "value-"+c.id)) != nil {
+		return nil, err
+	}
+	reply, err := handler(ctx, str)
+	if err != nil {
+		return nil, err
+	}
+	str, ok = reply.(string)
+	if !ok {
+		return nil, fmt.Errorf("unexpected response type: %T", reply)
+	}
+	str += "," + c.id
+	return str, nil
+}
+
+func (c *chainServerInterceptor) doStream(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	ctx := ss.Context()
+	md, ok := metadata.FromIncomingContext(ss.Context())
+	if ok {
+		md.Append("header-"+c.id, "value-"+c.id)
+		ctx = metadata.NewIncomingContext(ctx, md)
+	}
+	ss = &chainServerStream{ServerStream: ss, ctx: ctx, id: c.id}
+	if err := ss.SetHeader(metadata.Pairs("header-"+c.id, "value-"+c.id)); err != nil {
+		return err
+	}
+	if err := handler(srv, ss); err != nil {
+		return err
+	}
+	ss.SetTrailer(metadata.Pairs("trailer-"+c.id, "value-"+c.id))
+	return nil
+}
+
+type chainServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+	id  string
+}
+
+func (c *chainServerStream) Context() context.Context {
+	return c.ctx
+}
+
+func (c *chainServerStream) SendMsg(msg any) error {
+	str, ok := msg.(string)
+	if !ok {
+		return status.Errorf(codes.Internal, "unexpected message type: %T", msg)
+	}
+	str += "," + c.id
+	return c.ServerStream.SendMsg(str)
+}
+
+func (c *chainServerStream) RecvMsg(msg any) error {
+	str, ok := msg.(*string)
+	if !ok {
+		return status.Errorf(codes.Internal, "unexpected message type: %T", msg)
+	}
+	if err := c.ServerStream.RecvMsg(str); err != nil {
+		return err
+	}
+	*str += "," + c.id
+	return nil
+}
+
+type testChainHandler struct {
+	t *testing.T
+}
+
+func (t *testChainHandler) handleUnary(ctx context.Context, req any) (any, error) {
+	str, ok := req.(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid request: %T", req)
+	}
+	if str != "req,A,B,C" {
+		t.t.Errorf("unexpected request: %s", str)
+	}
+	headers, _ := metadata.FromIncomingContext(ctx)
+	expectHeaders := metadata.Pairs("header", "value", "header-A", "value-A", "header-B", "value-B", "header-C", "value-C")
+	if !reflect.DeepEqual(expectHeaders, headers) {
+		t.t.Errorf("unexpected headers: %s", headers)
+	}
+	if err := grpc.SetHeader(ctx, metadata.Pairs("header", "value")); err != nil {
+		return nil, err
+	}
+	if err := grpc.SetTrailer(ctx, metadata.Pairs("trailer", "value")); err != nil {
+		return nil, err
+	}
+	return "reply", nil
+}
+
+func (t *testChainHandler) handleStream(_ any, stream grpc.ServerStream) error {
+	headers, _ := metadata.FromIncomingContext(stream.Context())
+	expectHeaders := metadata.Pairs("header", "value", "header-A", "value-A", "header-B", "value-B", "header-C", "value-C")
+	if !reflect.DeepEqual(expectHeaders, headers) {
+		t.t.Errorf("unexpected headers: %s", headers)
+	}
+	var count int
+	for {
+		var req string
+		if err := stream.RecvMsg(&req); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+		count++
+		if req != "req"+strconv.Itoa(count)+",A,B,C" {
+			t.t.Errorf("unexpected request: %s", req)
+		}
+	}
+	if err := stream.SetHeader(metadata.Pairs("header", "value")); err != nil {
+		return err
+	}
+	for i := range count {
+		if err := stream.SendMsg("reply" + strconv.Itoa(count-i)); err != nil {
+			return err
+		}
+	}
+	stream.SetTrailer(metadata.Pairs("trailer", "value"))
+	return nil
+}
+
+func (t *testChainHandler) serviceDesc() *grpc.ServiceDesc {
+	unaryHandler := t.handleUnary
+	streamHandler := t.handleStream
+	return &grpc.ServiceDesc{
+		ServiceName: "foo",
+		HandlerType: (*any)(nil),
+		Methods: []grpc.MethodDesc{
+			{
+				MethodName: "bar",
+				Handler: func(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
+					var req string
+					if err := dec(&req); err != nil {
+						return nil, err
+					}
+					if interceptor != nil {
+						return interceptor(ctx, req, &grpc.UnaryServerInfo{Server: srv, FullMethod: "/foo/bar"}, unaryHandler)
+					}
+					return unaryHandler(ctx, req)
+				},
+			},
+		},
+		Streams: []grpc.StreamDesc{
+			{
+				StreamName: "bar",
+				Handler:    streamHandler,
+			},
+		},
+	}
+}
+
+type testChainStreamServer struct {
+	t         *testing.T
+	ctx       context.Context
+	reqSuffix string
+	done      bool
+	count     int
+
+	headers, trailers metadata.MD
+	sent              []string
+}
+
+func (t *testChainStreamServer) SetHeader(md metadata.MD) error {
+	if t.done {
+		return io.EOF
+	}
+	if t.headers == nil {
+		t.headers = metadata.MD{}
+	}
+	for k, v := range md {
+		t.headers[k] = append(t.headers[k], v...)
+	}
+	return nil
+}
+
+func (t *testChainStreamServer) SendHeader(md metadata.MD) error {
+	if err := t.SetHeader(md); err != nil {
+		return err
+	}
+	t.done = true
+	return nil
+}
+
+func (t *testChainStreamServer) SetTrailer(md metadata.MD) {
+	if t.trailers == nil {
+		t.trailers = metadata.MD{}
+	}
+	for k, v := range md {
+		t.trailers[k] = append(t.trailers[k], v...)
+	}
+}
+
+func (t *testChainStreamServer) Context() context.Context {
+	return t.ctx
+}
+
+func (t *testChainStreamServer) SendMsg(m any) error {
+	str, ok := m.(string)
+	if !ok {
+		return fmt.Errorf("invalid message: %T", m)
+	}
+	t.sent = append(t.sent, str)
+	return nil
+}
+
+func (t *testChainStreamServer) RecvMsg(m any) error {
+	if t.count == 3 {
+		return io.EOF
+	}
+	str, ok := m.(*string)
+	if !ok {
+		return fmt.Errorf("invalid message: %T", m)
+	}
+	t.count++
+	*str = "req" + strconv.Itoa(t.count) + t.reqSuffix
+	return nil
+}


### PR DESCRIPTION
This provides methods for intercepting client conns and servers that allow the user to provide a (var-arg) chain of interceptors. So if a user wants to apply multiple interceptors, this greatly simplifies usage.

The tests are kinda complicated, but they are basically asserting that every interceptor gets run once and in the expected order. And they test a variety of "setup" cases -- one that uses the chain to add an entire batch of interceptors at once and one that adds them one-at-a-time, etc -- to make sure they behave the same in all cases.

Resolves #72.