### PR TITLE
Adds a JSON/SSE transport for streaming endpoints to the http channel.

### DIFF
--- a/httpgrpc/client.go
+++ b/httpgrpc/client.go
@@ -34,46 +34,48 @@ import (
 	"github.com/fullstorydev/grpchan/internal"
 )
 
+// ChannelOption is a function that can be used to configure a Channel.
+type ChannelOption func(*channelOptions)
+
+type channelOptions struct {
+	// TODO(kellegous): It would be ideal if this were refactored into a protocol abstraction that encapsulates the message-level codec and the framing strategy
+	// into a single object. That would all us to have size-prefixed proto, json+see, connectRPC ... anything else.
+	useJSONEncoding bool
+}
+
+// WithJSONEncoding configures the channel to use JSON encoding between the client and server.
+// For unary calls, the request and response are JSON values. For streaming calls, the request is
+// a series of JSON values and the response is SSE events containing JSON values.
+func WithJSONEncoding(useJSONEncoding bool) ChannelOption {
+	return func(o *channelOptions) {
+		o.useJSONEncoding = useJSONEncoding
+	}
+}
+
+// NewChannel creates a new Channel with the given base URL and transport.
+// The ChannelOption functions can be used to configure the Channel.
+func NewChannel(baseURL *url.URL, transport http.RoundTripper, opts ...ChannelOption) *Channel {
+	c := &Channel{
+		BaseURL:   baseURL,
+		Transport: transport,
+	}
+
+	for _, opt := range opts {
+		opt(&c.channelOptions)
+	}
+
+	return c
+}
+
 // Channel is used as a connection for GRPC requests issued over HTTP 1.1. The
 // server endpoint is configured using the BaseURL field, and the Transport can
 // also be configured. Both of those fields must be specified.
 //
 // It implements version 1 of the GRPC-over-HTTP transport protocol.
 type Channel struct {
-	Transport   http.RoundTripper
-	BaseURL     *url.URL
-	ContentType ContentType
-}
-
-type ContentType int
-
-const (
-	// ContentTypeProto uses binary encoded proto messages over the channel.
-	ContentTypeProto ContentType = iota
-
-	// ContentTypeJSON uses JSON-encoded messages over the channel. For unary calls,
-	// the request and response are JSON values. For streaming calls, the request is
-	// a series of JSON values and the response is SSE events containing JSON values.
-	// This is primariy intended for testing the SSE streaming server implementation.
-	ContentTypeJSON
-)
-
-func (c *Channel) getUnaryContentType() string {
-	switch c.ContentType {
-	case ContentTypeJSON:
-		return ApplicationJson
-	default:
-		return UnaryRpcContentType_V1
-	}
-}
-
-func (c *Channel) getStreamingContentType() string {
-	switch c.ContentType {
-	case ContentTypeJSON:
-		return ApplicationJson
-	default:
-		return StreamRpcContentType_V1
-	}
+	Transport http.RoundTripper
+	BaseURL   *url.URL
+	channelOptions
 }
 
 var _ grpc.ClientConnInterface = (*Channel)(nil)
@@ -92,12 +94,8 @@ func (ch *Channel) Invoke(ctx context.Context, methodName string, req, resp inte
 	if err != nil {
 		return err
 	}
-	h := headersFromContext(ctx)
 
-	contentType := ch.getUnaryContentType()
-	h.Set("Content-Type", contentType)
-
-	codec := getUnaryCodec(contentType)
+	h, codec := getHeadersAndCodecForClientUnaryRequest(ctx, ch.useJSONEncoding)
 	buf, err := codec.Marshal(req)
 	if err != nil {
 		return err
@@ -168,10 +166,7 @@ func (ch *Channel) NewStream(ctx context.Context, desc *grpc.StreamDesc, methodN
 
 	ctx, cancel := context.WithCancel(ctx)
 
-	contentType := ch.getStreamingContentType()
-
-	h := headersFromContext(ctx)
-	h.Set("Content-Type", contentType)
+	h, newStreamWriter := getHeadersAndCodecForClientStreamingRequest(ctx, ch.useJSONEncoding)
 
 	// Intercept r.Close() so we can control the error sent across to the writer thread.
 	r, w := io.Pipe()
@@ -182,7 +177,7 @@ func (ch *Channel) NewStream(ctx context.Context, desc *grpc.StreamDesc, methodN
 	}
 	req.Header = h
 
-	cs := newClientStream(ctx, cancel, w, desc.ServerStreams, copts, ch.BaseURL, contentType)
+	cs := newClientStream(ctx, cancel, w, desc.ServerStreams, copts, ch.BaseURL, newStreamWriter(w))
 	go cs.doHttpCall(ch.Transport, req, r)
 
 	// ensure that context is cancelled, even if caller
@@ -282,20 +277,17 @@ func newClientStream(
 	recvStream bool,
 	copts *internal.CallOptions,
 	baseUrl *url.URL,
-	contentType string,
+	streamWriter streamWriter,
 ) *clientStream {
 	cs := &clientStream{
 		ctx:          ctx,
 		cancel:       cancel,
 		copts:        copts,
 		baseUrl:      baseUrl,
-		streamWriter: getClientStreamWriter(contentType, w),
+		streamWriter: streamWriter,
 		w:            w,
 		respStream:   recvStream,
 		rCh:          make(chan streamMsg),
-	}
-	if cs.streamWriter == nil {
-		panic(fmt.Sprintf("unsupported media type: %s", contentType))
 	}
 	cs.ready.Add(1)
 	return cs

--- a/httpgrpc/client.go
+++ b/httpgrpc/client.go
@@ -6,9 +6,9 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"google.golang.org/grpc/mem"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"net/textproto"
 	"net/url"
@@ -19,12 +19,12 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/grpc/mem"
+
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/encoding"
-	grpcproto "google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
@@ -40,8 +40,40 @@ import (
 //
 // It implements version 1 of the GRPC-over-HTTP transport protocol.
 type Channel struct {
-	Transport http.RoundTripper
-	BaseURL   *url.URL
+	Transport   http.RoundTripper
+	BaseURL     *url.URL
+	ContentType ContentType
+}
+
+type ContentType int
+
+const (
+	// ContentTypeProto uses binary encoded proto messages over the channel.
+	ContentTypeProto ContentType = iota
+
+	// ContentTypeJSON uses JSON-encoded messages over the channel. For unary calls,
+	// the request and response are JSON values. For streaming calls, the request is
+	// a series of JSON values and the response is SSE events containing JSON values.
+	// This is primariy intended for testing the SSE streaming server implementation.
+	ContentTypeJSON
+)
+
+func (c *Channel) getUnaryContentType() string {
+	switch c.ContentType {
+	case ContentTypeJSON:
+		return ApplicationJson
+	default:
+		return UnaryRpcContentType_V1
+	}
+}
+
+func (c *Channel) getStreamingContentType() string {
+	switch c.ContentType {
+	case ContentTypeJSON:
+		return ApplicationJson
+	default:
+		return StreamRpcContentType_V1
+	}
 }
 
 var _ grpc.ClientConnInterface = (*Channel)(nil)
@@ -61,9 +93,11 @@ func (ch *Channel) Invoke(ctx context.Context, methodName string, req, resp inte
 		return err
 	}
 	h := headersFromContext(ctx)
-	h.Set("Content-Type", UnaryRpcContentType_V1)
 
-	codec := encoding.GetCodecV2(grpcproto.Name)
+	contentType := ch.getUnaryContentType()
+	h.Set("Content-Type", contentType)
+
+	codec := getUnaryCodec(contentType)
 	buf, err := codec.Marshal(req)
 	if err != nil {
 		return err
@@ -134,8 +168,10 @@ func (ch *Channel) NewStream(ctx context.Context, desc *grpc.StreamDesc, methodN
 
 	ctx, cancel := context.WithCancel(ctx)
 
+	contentType := ch.getStreamingContentType()
+
 	h := headersFromContext(ctx)
-	h.Set("Content-Type", StreamRpcContentType_V1)
+	h.Set("Content-Type", contentType)
 
 	// Intercept r.Close() so we can control the error sent across to the writer thread.
 	r, w := io.Pipe()
@@ -146,7 +182,7 @@ func (ch *Channel) NewStream(ctx context.Context, desc *grpc.StreamDesc, methodN
 	}
 	req.Header = h
 
-	cs := newClientStream(ctx, cancel, w, desc.ServerStreams, copts, ch.BaseURL)
+	cs := newClientStream(ctx, cancel, w, desc.ServerStreams, copts, ch.BaseURL, contentType)
 	go cs.doHttpCall(ch.Transport, req, r)
 
 	// ensure that context is cancelled, even if caller
@@ -211,7 +247,8 @@ type clientStream struct {
 	cancel  context.CancelFunc
 	copts   *internal.CallOptions
 	baseUrl *url.URL
-	codec   encoding.CodecV2
+
+	streamWriter streamWriter
 
 	// respStream is set to indicate whether client expects stream response; unary if false
 	respStream bool
@@ -224,7 +261,7 @@ type clientStream struct {
 	// rCh is used to deliver messages from doHttpCall goroutine
 	// to callers of RecvMsg.
 	// done must be set to true before it is closed
-	rCh chan []byte
+	rCh chan streamMsg
 
 	// rMu protects done, rErr, and tr
 	rMu  sync.RWMutex
@@ -238,16 +275,27 @@ type clientStream struct {
 	wErr error
 }
 
-func newClientStream(ctx context.Context, cancel context.CancelFunc, w io.WriteCloser, recvStream bool, copts *internal.CallOptions, baseUrl *url.URL) *clientStream {
+func newClientStream(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	w io.WriteCloser,
+	recvStream bool,
+	copts *internal.CallOptions,
+	baseUrl *url.URL,
+	contentType string,
+) *clientStream {
 	cs := &clientStream{
-		ctx:        ctx,
-		cancel:     cancel,
-		copts:      copts,
-		baseUrl:    baseUrl,
-		codec:      encoding.GetCodecV2(grpcproto.Name),
-		w:          w,
-		respStream: recvStream,
-		rCh:        make(chan []byte),
+		ctx:          ctx,
+		cancel:       cancel,
+		copts:        copts,
+		baseUrl:      baseUrl,
+		streamWriter: getClientStreamWriter(contentType, w),
+		w:            w,
+		respStream:   recvStream,
+		rCh:          make(chan streamMsg),
+	}
+	if cs.streamWriter == nil {
+		panic(fmt.Sprintf("unsupported media type: %s", contentType))
 	}
 	cs.ready.Add(1)
 	return cs
@@ -319,7 +367,7 @@ func (cs *clientStream) SendMsg(m interface{}) error {
 		return io.EOF
 	}
 
-	cs.wErr = writeProtoMessage(cs.w, cs.codec, m, false)
+	cs.wErr = cs.streamWriter(m, false)
 	return cs.wErr
 }
 
@@ -340,7 +388,7 @@ func (cs *clientStream) RecvMsg(m interface{}) error {
 			}
 			return err
 		}
-		err := cs.codec.Unmarshal(mem.BufferSlice{mem.SliceBuffer(msg)}, m)
+		err := msg.Decode(m)
 		if err != nil {
 			return status.Error(codes.Internal, fmt.Sprintf("server sent invalid message: %v", err))
 		}
@@ -446,21 +494,33 @@ func (cs *clientStream) doHttpCall(transport http.RoundTripper, req *http.Reques
 		return
 	}
 
+	contentType := reply.Header.Get("Content-Type")
+	mediaType, _, _ := mime.ParseMediaType(contentType)
+	streamReader := getClientStreamReader(mediaType, reply.Body)
+
+	if streamReader == nil {
+		onReady(status.Error(codes.Internal, fmt.Sprintf("unsupported media type: %s", mediaType)), nil)
+		return
+	}
+
 	counter := 0
 	for {
 		// TODO: enforce max send and receive size in call options
 
 		counter++
-		var sz int32
-		sz, rErr = readSizePreface(reply.Body)
+		var msg streamMsg
+		msg, rErr = streamReader()
 		if rErr != nil {
+			if rErr == io.EOF {
+				rErr = io.ErrUnexpectedEOF
+			}
 			return
 		}
-		if sz < 0 {
+		if msg.isTrailer {
 			// final message is a trailer (need lock to write to cs.tr)
 			cs.rMu.Lock()
 			rMuHeld = true // defer above will unlock for us
-			cs.rErr = readProtoMessage(reply.Body, cs.codec, int32(-sz), &cs.tr)
+			cs.rErr = msg.Decode(&cs.tr)
 			if cs.rErr != nil {
 				if cs.rErr == io.EOF {
 					cs.rErr = io.ErrUnexpectedEOF
@@ -468,14 +528,6 @@ func (cs *clientStream) doHttpCall(transport http.RoundTripper, req *http.Reques
 			}
 			if len(cs.tr.Metadata) > 0 && len(cs.copts.Trailers) > 0 {
 				cs.copts.SetTrailers(metadataFromProto(cs.tr.Metadata))
-			}
-			return
-		}
-		msg := make([]byte, sz)
-		_, rErr = io.ReadAtLeast(reply.Body, msg, int(sz))
-		if rErr != nil {
-			if rErr == io.EOF {
-				rErr = io.ErrUnexpectedEOF
 			}
 			return
 		}

--- a/httpgrpc/httpgrpc_test.go
+++ b/httpgrpc/httpgrpc_test.go
@@ -128,18 +128,14 @@ func TestJSONSSEServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse base URL: %v", err)
 	}
-	cc := httpgrpc.Channel{
-		Transport:   http.DefaultTransport,
-		BaseURL:     u,
-		ContentType: httpgrpc.ContentTypeJSON,
-	}
+	cc := httpgrpc.NewChannel(u, http.DefaultTransport, httpgrpc.WithJSONEncoding(true))
 
-	grpchantesting.RunChannelTestCases(t, &cc, false)
+	grpchantesting.RunChannelTestCases(t, cc, false)
 
 	t.Run("empty-trailer", func(t *testing.T) {
 		// test RPC w/ streaming response where trailer message is empty
 		// (e.g. no trailer metadata and code == 0 [OK])
-		cli := grpchantesting.NewTestServiceClient(&cc)
+		cli := grpchantesting.NewTestServiceClient(cc)
 		str, err := cli.ServerStream(context.Background(), &grpchantesting.Message{})
 		if err != nil {
 			t.Fatalf("failed to initiate server stream: %v", err)

--- a/httpgrpc/httpgrpc_test.go
+++ b/httpgrpc/httpgrpc_test.go
@@ -64,7 +64,6 @@ func TestGrpcOverHttp(t *testing.T) {
 // *httpgrpc.Server instead of httpgrpc.HandleServices.
 func TestServer(t *testing.T) {
 	errFunc := func(reqCtx context.Context, st *status.Status, response http.ResponseWriter) {
-
 	}
 
 	svc := &grpchantesting.TestServer{}
@@ -87,6 +86,52 @@ func TestServer(t *testing.T) {
 	cc := httpgrpc.Channel{
 		Transport: http.DefaultTransport,
 		BaseURL:   u,
+	}
+
+	grpchantesting.RunChannelTestCases(t, &cc, false)
+
+	t.Run("empty-trailer", func(t *testing.T) {
+		// test RPC w/ streaming response where trailer message is empty
+		// (e.g. no trailer metadata and code == 0 [OK])
+		cli := grpchantesting.NewTestServiceClient(&cc)
+		str, err := cli.ServerStream(context.Background(), &grpchantesting.Message{})
+		if err != nil {
+			t.Fatalf("failed to initiate server stream: %v", err)
+		}
+		// if there is an issue with trailer message, it will appear to be
+		// a regular message and err would be nil
+		_, err = str.Recv()
+		if err != io.EOF {
+			t.Fatalf("server stream should not have returned any messages")
+		}
+	})
+}
+
+func TestJSONSSEServer(t *testing.T) {
+	errFunc := func(reqCtx context.Context, st *status.Status, response http.ResponseWriter) {
+	}
+
+	svc := &grpchantesting.TestServer{}
+	svr := httpgrpc.NewServer(httpgrpc.WithBasePath("/foo/"), httpgrpc.ErrorRenderer(errFunc))
+	grpchantesting.RegisterTestServiceServer(svr, svc)
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed it listen on socket: %v", err)
+	}
+	httpServer := http.Server{Handler: svr}
+	go httpServer.Serve(l)
+	defer httpServer.Close()
+
+	// now setup client stub
+	u, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d/foo/", l.Addr().(*net.TCPAddr).Port))
+	if err != nil {
+		t.Fatalf("failed to parse base URL: %v", err)
+	}
+	cc := httpgrpc.Channel{
+		Transport:   http.DefaultTransport,
+		BaseURL:     u,
+		ContentType: httpgrpc.ContentTypeJSON,
 	}
 
 	grpchantesting.RunChannelTestCases(t, &cc, false)

--- a/httpgrpc/io.go
+++ b/httpgrpc/io.go
@@ -72,24 +72,6 @@ func readSizePreface(in io.Reader) (int32, error) {
 	return sz, err
 }
 
-// readProtoMessage reads data from the given reader and decodes it into the given
-// message. The sz parameter indicates the  number of bytes that must be read to
-// decode the proto. This does not first call readSizePreface; callers must do that
-// first.
-func readProtoMessage(in io.Reader, codec encoding.CodecV2, sz int32, m interface{}) error {
-	if sz < 0 {
-		return fmt.Errorf("bad size preface: size cannot be negative: %d", sz)
-	} else if sz > maxMessageSize {
-		return fmt.Errorf("bad size preface: indicated size is too large: %d", sz)
-	}
-	msg := make([]byte, sz)
-	_, err := io.ReadAtLeast(in, msg, int(sz))
-	if err != nil {
-		return err
-	}
-	return codec.Unmarshal(mem.BufferSlice{mem.SliceBuffer(msg)}, m)
-}
-
 // asMetadata converts the given HTTP headers into GRPC metadata.
 func asMetadata(header http.Header) (metadata.MD, error) {
 	// metadata has same shape as http.Header,
@@ -244,6 +226,10 @@ func newSizePrefixedReader(r io.Reader, codec encoding.CodecV2) func() (streamMs
 		isTrailer := size < 0
 		if isTrailer {
 			size = -size
+		}
+
+		if size > maxMessageSize {
+			return streamMsg{}, fmt.Errorf("bad size preface: indicated size is too large: %d", size)
 		}
 
 		data := make([]byte, size)

--- a/httpgrpc/io.go
+++ b/httpgrpc/io.go
@@ -3,12 +3,16 @@ package httpgrpc
 import (
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
-	"google.golang.org/grpc/mem"
 	"io"
 	"math"
 	"net/http"
 	"strings"
+
+	"github.com/fullstorydev/grpchan/internal/sse"
+	grpcproto "google.golang.org/grpc/encoding/proto"
+	"google.golang.org/grpc/mem"
 
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/metadata"
@@ -155,3 +159,184 @@ func (a strAddr) Network() string {
 }
 
 func (a strAddr) String() string { return string(a) }
+
+type streamReader func() (streamMsg, error)
+
+type streamWriter func(m any, isTrailer bool) error
+
+type flusher interface {
+	Flush() error
+}
+
+func getServerStreamWriter(mediaType string, w io.Writer, flusher flusher) (streamWriter, string) {
+	if mediaType == StreamRpcContentType_V1 {
+		codec := encoding.GetCodecV2(grpcproto.Name)
+		return newSizePrefixedWriter(w, codec), StreamRpcContentType_V1
+	}
+
+	if mediaType == ApplicationJson {
+		codec := encoding.GetCodecV2("json")
+		return newSSEWriter(w, flusher, codec), EventStreamContentType
+	}
+
+	return nil, ""
+}
+
+func getServerStreamReader(mediaType string, r io.Reader) streamReader {
+	if mediaType == StreamRpcContentType_V1 {
+		codec := encoding.GetCodecV2(grpcproto.Name)
+		return newSizePrefixedReader(r, codec)
+	}
+
+	if mediaType == ApplicationJson {
+		codec := encoding.GetCodecV2("json")
+		return newJSONReader(r, codec)
+	}
+
+	return nil
+}
+
+func getClientStreamReader(mediaType string, r io.Reader) streamReader {
+	if mediaType == StreamRpcContentType_V1 {
+		codec := encoding.GetCodecV2(grpcproto.Name)
+		return newSizePrefixedReader(r, codec)
+	}
+
+	if mediaType == EventStreamContentType {
+		codec := encoding.GetCodecV2("json")
+		return newSSEReader(r, codec)
+	}
+
+	return nil
+}
+
+func getClientStreamWriter(mediaType string, w io.Writer) streamWriter {
+	if mediaType == StreamRpcContentType_V1 {
+		codec := encoding.GetCodecV2(grpcproto.Name)
+		return newSizePrefixedWriter(w, codec)
+	}
+
+	if mediaType == ApplicationJson {
+		codec := encoding.GetCodecV2("json")
+		return newJSONWriter(w, codec)
+	}
+
+	return nil
+}
+
+type streamMsg struct {
+	codec     encoding.CodecV2
+	data      []byte
+	isTrailer bool
+}
+
+func (s *streamMsg) Decode(m any) error {
+	return s.codec.Unmarshal(mem.BufferSlice{mem.SliceBuffer(s.data)}, m)
+}
+
+func newSizePrefixedReader(r io.Reader, codec encoding.CodecV2) func() (streamMsg, error) {
+	return func() (streamMsg, error) {
+		size, err := readSizePreface(r)
+		if err != nil {
+			return streamMsg{}, err
+		}
+
+		isTrailer := size < 0
+		if isTrailer {
+			size = -size
+		}
+
+		data := make([]byte, size)
+		_, err = io.ReadAtLeast(r, data, int(size))
+		if err != nil {
+			return streamMsg{}, err
+		}
+
+		return streamMsg{
+			codec:     codec,
+			data:      data,
+			isTrailer: isTrailer,
+		}, nil
+	}
+}
+
+func newSizePrefixedWriter(w io.Writer, codec encoding.CodecV2) func(m any, isTrailer bool) error {
+	return func(m any, isTrailer bool) error {
+		return writeProtoMessage(w, codec, m, isTrailer)
+	}
+}
+
+func newJSONReader(r io.Reader, codec encoding.CodecV2) func() (streamMsg, error) {
+	d := json.NewDecoder(r)
+	return func() (streamMsg, error) {
+		var msg json.RawMessage
+		if err := d.Decode(&msg); err != nil {
+			return streamMsg{}, err
+		}
+
+		return streamMsg{
+			codec: codec,
+			data:  msg,
+		}, nil
+	}
+}
+
+func newJSONWriter(w io.Writer, codec encoding.CodecV2) func(m any, isTrailer bool) error {
+	return func(m any, isTrailer bool) error {
+		if isTrailer {
+			panic("trailers are not supported for JSON")
+		}
+
+		data, err := codec.Marshal(m)
+		if err != nil {
+			return err
+		}
+
+		_, err = w.Write(data.Materialize())
+		return err
+	}
+}
+
+func newSSEWriter(w io.Writer, flusher flusher, codec encoding.CodecV2) func(m any, isTrailer bool) error {
+	e := sse.NewEncoder(w)
+	return func(m any, isTrailer bool) error {
+		data, err := codec.Marshal(m)
+		if err != nil {
+			return err
+		}
+
+		if isTrailer {
+			if err := e.Encode(&sse.Event{
+				Type: "trailer",
+				Data: data.Materialize(),
+			}); err != nil {
+				return err
+			}
+		} else {
+			if err := e.Encode(&sse.Event{
+				Data: data.Materialize(),
+			}); err != nil {
+				return err
+			}
+		}
+
+		return flusher.Flush()
+	}
+}
+
+func newSSEReader(r io.Reader, codec encoding.CodecV2) func() (streamMsg, error) {
+	d := sse.NewDecoder(r)
+
+	return func() (streamMsg, error) {
+		event, err := d.Decode()
+		if err != nil {
+			return streamMsg{}, err
+		}
+
+		return streamMsg{
+			codec:     codec,
+			data:      event.Data,
+			isTrailer: event.Type == "trailer",
+		}, nil
+	}
+}

--- a/httpgrpc/io.go
+++ b/httpgrpc/io.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -11,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/fullstorydev/grpchan/internal/sse"
-	grpcproto "google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/mem"
 
 	"google.golang.org/grpc/encoding"
@@ -69,6 +69,16 @@ func writeProtoMessage(w io.Writer, codec encoding.CodecV2, m interface{}, end b
 func readSizePreface(in io.Reader) (int32, error) {
 	var sz int32
 	err := binary.Read(in, binary.BigEndian, &sz)
+	if err != nil {
+		return 0, err
+	}
+	// Reject math.MinInt32: negating it overflows in two's complement and would
+	// mean that -size would remain negative and potentially cause a panic if the
+	// callers tries to allocate a buffer for the message.
+	if sz == math.MinInt32 {
+		return 0, errors.New("bad size preface: size overflow")
+	}
+
 	return sz, err
 }
 
@@ -150,62 +160,6 @@ type flusher interface {
 	Flush() error
 }
 
-func getServerStreamWriter(mediaType string, w io.Writer, flusher flusher) (streamWriter, string) {
-	if mediaType == StreamRpcContentType_V1 {
-		codec := encoding.GetCodecV2(grpcproto.Name)
-		return newSizePrefixedWriter(w, codec), StreamRpcContentType_V1
-	}
-
-	if mediaType == ApplicationJson {
-		codec := encoding.GetCodecV2("json")
-		return newSSEWriter(w, flusher, codec), EventStreamContentType
-	}
-
-	return nil, ""
-}
-
-func getServerStreamReader(mediaType string, r io.Reader) streamReader {
-	if mediaType == StreamRpcContentType_V1 {
-		codec := encoding.GetCodecV2(grpcproto.Name)
-		return newSizePrefixedReader(r, codec)
-	}
-
-	if mediaType == ApplicationJson {
-		codec := encoding.GetCodecV2("json")
-		return newJSONReader(r, codec)
-	}
-
-	return nil
-}
-
-func getClientStreamReader(mediaType string, r io.Reader) streamReader {
-	if mediaType == StreamRpcContentType_V1 {
-		codec := encoding.GetCodecV2(grpcproto.Name)
-		return newSizePrefixedReader(r, codec)
-	}
-
-	if mediaType == EventStreamContentType {
-		codec := encoding.GetCodecV2("json")
-		return newSSEReader(r, codec)
-	}
-
-	return nil
-}
-
-func getClientStreamWriter(mediaType string, w io.Writer) streamWriter {
-	if mediaType == StreamRpcContentType_V1 {
-		codec := encoding.GetCodecV2(grpcproto.Name)
-		return newSizePrefixedWriter(w, codec)
-	}
-
-	if mediaType == ApplicationJson {
-		codec := encoding.GetCodecV2("json")
-		return newJSONWriter(w, codec)
-	}
-
-	return nil
-}
-
 type streamMsg struct {
 	codec     encoding.CodecV2
 	data      []byte
@@ -234,7 +188,9 @@ func newSizePrefixedReader(r io.Reader, codec encoding.CodecV2) func() (streamMs
 
 		data := make([]byte, size)
 		_, err = io.ReadAtLeast(r, data, int(size))
-		if err != nil {
+		if errors.Is(err, io.EOF) { // io.EOF is returned if no bytes were read
+			return streamMsg{}, io.ErrUnexpectedEOF
+		} else if err != nil {
 			return streamMsg{}, err
 		}
 

--- a/httpgrpc/json.go
+++ b/httpgrpc/json.go
@@ -9,6 +9,8 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
+const jsonCodecName = "json"
+
 var (
 	grpcJsonMarshaler = protojson.MarshalOptions{
 		UseEnumNumbers:  true,
@@ -38,5 +40,5 @@ func (c jsonCodec) Unmarshal(data mem.BufferSlice, v interface{}) error {
 }
 
 func (c jsonCodec) Name() string {
-	return "json"
+	return jsonCodecName
 }

--- a/httpgrpc/protocol_versions.go
+++ b/httpgrpc/protocol_versions.go
@@ -1,7 +1,10 @@
 package httpgrpc
 
 import (
+	"context"
+	"io"
 	"mime"
+	"net/http"
 
 	"google.golang.org/grpc/encoding"
 	grpcproto "google.golang.org/grpc/encoding/proto"
@@ -49,7 +52,9 @@ const (
 	EventStreamContentType = "text/event-stream"
 )
 
-func getUnaryCodec(contentType string) encoding.CodecV2 {
+// getCodecForServerUnaryResponse returns the codec to use to handle a unary request on
+// the server, based on the Content-Type headers from the incoming request.
+func getCodecForServerUnaryResponse(contentType string) encoding.CodecV2 {
 	// Ignore any errors or charsets for now, just parse the main type.
 	// TODO: should this be more picky / return an error?  Maybe charset utf8 only?
 	mediaType, _, _ := mime.ParseMediaType(contentType)
@@ -60,6 +65,78 @@ func getUnaryCodec(contentType string) encoding.CodecV2 {
 
 	if mediaType == ApplicationJson {
 		return encoding.GetCodecV2("json")
+	}
+
+	return nil
+}
+
+// getServerStreamReaderAndWriter returns the reader and writer to use to handle a streaming request on
+// the server, based on the Content-Type headers from the incoming request.
+func getServerStreamReaderAndWriter(contentType string, r io.Reader, w io.Writer, flusher flusher) (streamReader, streamWriter, string) {
+	// Ignore any errors or charsets for now, just parse the main type.
+	// TODO: should this be more picky / return an error?  Maybe charset utf8 only?
+	mediaType, _, _ := mime.ParseMediaType(contentType)
+
+	if mediaType == StreamRpcContentType_V1 {
+		codec := encoding.GetCodecV2(grpcproto.Name)
+		return newSizePrefixedReader(r, codec), newSizePrefixedWriter(w, codec), StreamRpcContentType_V1
+	}
+
+	if mediaType == ApplicationJson {
+		codec := encoding.GetCodecV2("json")
+		return newJSONReader(r, codec), newSSEWriter(w, flusher, codec), EventStreamContentType
+	}
+
+	return nil, nil, ""
+}
+
+// getHeadersAndCodecForClientUnaryRequest returns the headers and codec to use to handle a unary request on
+// the client, based on the the configuration of the client (currently whether to use JSON encoding).
+func getHeadersAndCodecForClientUnaryRequest(ctx context.Context, useJSONEncoding bool) (http.Header, encoding.CodecV2) {
+	h := headersFromContext(ctx)
+	if useJSONEncoding {
+		h.Set("Content-Type", ApplicationJson)
+		return h, encoding.GetCodecV2("json")
+	}
+
+	h.Set("Content-Type", UnaryRpcContentType_V1)
+	return h, encoding.GetCodecV2(grpcproto.Name)
+}
+
+// getHeadersAndCodecForClientStreamingRequest returns the headers and writer to use to handle a streaming request on
+// the client, based on the the configuration of the client (currently whether to use JSON encoding).
+func getHeadersAndCodecForClientStreamingRequest(ctx context.Context, useJSONEncoding bool) (http.Header, func(w io.Writer) streamWriter) {
+	h := headersFromContext(ctx)
+	if useJSONEncoding {
+		h.Set("Content-Type", ApplicationJson)
+		h.Set("Accept", EventStreamContentType)
+		return h, func(w io.Writer) streamWriter {
+			return newJSONWriter(w, encoding.GetCodecV2("json"))
+		}
+	}
+
+	h.Set("Content-Type", StreamRpcContentType_V1)
+	h.Set("Accept", StreamRpcContentType_V1)
+	return h, func(w io.Writer) streamWriter {
+		return newSizePrefixedWriter(w, encoding.GetCodecV2(grpcproto.Name))
+	}
+}
+
+// getClientStreamReader returns the reader to use to handle a streaming result on
+// the client, based on the Content-Type header that was returned from the server.
+func getClientStreamReader(contentType string, r io.Reader) streamReader {
+	// Ignore any errors or charsets for now, just parse the main type.
+	// TODO: should this be more picky / return an error?  Maybe charset utf8 only?
+	mediaType, _, _ := mime.ParseMediaType(contentType)
+
+	if mediaType == StreamRpcContentType_V1 {
+		codec := encoding.GetCodecV2(grpcproto.Name)
+		return newSizePrefixedReader(r, codec)
+	}
+
+	if mediaType == EventStreamContentType {
+		codec := encoding.GetCodecV2("json")
+		return newSSEReader(r, codec)
 	}
 
 	return nil

--- a/httpgrpc/protocol_versions.go
+++ b/httpgrpc/protocol_versions.go
@@ -64,7 +64,7 @@ func getCodecForServerUnaryResponse(contentType string) encoding.CodecV2 {
 	}
 
 	if mediaType == ApplicationJson {
-		return encoding.GetCodecV2("json")
+		return encoding.GetCodecV2(jsonCodecName)
 	}
 
 	return nil
@@ -83,7 +83,7 @@ func getServerStreamReaderAndWriter(contentType string, r io.Reader, w io.Writer
 	}
 
 	if mediaType == ApplicationJson {
-		codec := encoding.GetCodecV2("json")
+		codec := encoding.GetCodecV2(jsonCodecName)
 		return newJSONReader(r, codec), newSSEWriter(w, flusher, codec), EventStreamContentType
 	}
 
@@ -96,7 +96,7 @@ func getHeadersAndCodecForClientUnaryRequest(ctx context.Context, useJSONEncodin
 	h := headersFromContext(ctx)
 	if useJSONEncoding {
 		h.Set("Content-Type", ApplicationJson)
-		return h, encoding.GetCodecV2("json")
+		return h, encoding.GetCodecV2(jsonCodecName)
 	}
 
 	h.Set("Content-Type", UnaryRpcContentType_V1)
@@ -111,7 +111,7 @@ func getHeadersAndCodecForClientStreamingRequest(ctx context.Context, useJSONEnc
 		h.Set("Content-Type", ApplicationJson)
 		h.Set("Accept", EventStreamContentType)
 		return h, func(w io.Writer) streamWriter {
-			return newJSONWriter(w, encoding.GetCodecV2("json"))
+			return newJSONWriter(w, encoding.GetCodecV2(jsonCodecName))
 		}
 	}
 
@@ -135,7 +135,7 @@ func getClientStreamReader(contentType string, r io.Reader) streamReader {
 	}
 
 	if mediaType == EventStreamContentType {
-		codec := encoding.GetCodecV2("json")
+		codec := encoding.GetCodecV2(jsonCodecName)
 		return newSSEReader(r, codec)
 	}
 

--- a/httpgrpc/protocol_versions.go
+++ b/httpgrpc/protocol_versions.go
@@ -40,9 +40,13 @@ const (
 
 const (
 	// Non-standard and experimental; uses the `jsonpb.Marshaler` by default.
-	// Only unary calls are supported; streams with JSON encoding are not supported.
 	// Use `encoding.RegisterCodecV2` to override the default encoder with a custom encoder.
+	// Unary calls use JSON encoding for the request and response. Streaming calls from the
+	// client to the server use JSON encoding with mutiple values. Streaming calls from the
+	// server to the client use SSE encoding with multiple events.
 	ApplicationJson = "application/json"
+
+	EventStreamContentType = "text/event-stream"
 )
 
 func getUnaryCodec(contentType string) encoding.CodecV2 {
@@ -56,24 +60,6 @@ func getUnaryCodec(contentType string) encoding.CodecV2 {
 
 	if mediaType == ApplicationJson {
 		return encoding.GetCodecV2("json")
-	}
-
-	return nil
-}
-
-func getStreamingCodec(contentType string) encoding.CodecV2 {
-	// Ignore any errors or charsets for now, just parse the main type.
-	// TODO: should this be more picky / return an error?  Maybe charset utf8 only?
-	mediaType, _, _ := mime.ParseMediaType(contentType)
-
-	if mediaType == StreamRpcContentType_V1 {
-		return encoding.GetCodecV2(grpcproto.Name)
-	}
-
-	if mediaType == ApplicationJson {
-		// TODO: support half-duplix JSON streaming?
-		// https://en.wikipedia.org/wiki/JSON_streaming#Record_separator-delimited_JSON
-		return nil
 	}
 
 	return nil

--- a/httpgrpc/server.go
+++ b/httpgrpc/server.go
@@ -5,19 +5,22 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"google.golang.org/grpc/mem"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"path"
 	"strconv"
 	"sync"
 	"time"
 
+	"google.golang.org/grpc/mem"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding"
+	grpcproto "google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
@@ -38,8 +41,10 @@ type Server struct {
 	opts      handlerOpts
 }
 
-var _ http.Handler = (*Server)(nil)
-var _ grpc.ServiceRegistrar = (*Server)(nil)
+var (
+	_ http.Handler          = (*Server)(nil)
+	_ grpc.ServiceRegistrar = (*Server)(nil)
+)
 
 // ServerOption is an option used when constructing a NewServer.
 type ServerOption interface {
@@ -301,8 +306,9 @@ func handleMethod(svr interface{}, serviceName string, desc *grpc.MethodDesc, un
 			}
 			statProto := st.Proto()
 			w.Header().Set("X-GRPC-Status", fmt.Sprintf("%d:%s", statProto.Code, statProto.Message))
+			protoCodec := encoding.GetCodecV2(grpcproto.Name)
 			for _, d := range statProto.Details {
-				buf, err := codec.Marshal(d)
+				buf, err := protoCodec.Marshal(d)
 				if err != nil {
 					continue
 				}
@@ -356,8 +362,17 @@ func handleStream(svr interface{}, serviceName string, desc *grpc.StreamDesc, st
 		}
 
 		contentType := r.Header.Get("Content-Type")
-		codec := getStreamingCodec(contentType)
-		if codec == nil {
+
+		mediaType, _, _ := mime.ParseMediaType(contentType)
+
+		streamWriter, resContentType := getServerStreamWriter(mediaType, w, http.NewResponseController(w))
+		if streamWriter == nil {
+			writeError(w, http.StatusUnsupportedMediaType)
+			return
+		}
+
+		streamReader := getServerStreamReader(mediaType, r.Body)
+		if streamReader == nil {
 			writeError(w, http.StatusUnsupportedMediaType)
 			return
 		}
@@ -369,9 +384,9 @@ func handleStream(svr interface{}, serviceName string, desc *grpc.StreamDesc, st
 		}
 		defer cancel()
 
-		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("Content-Type", resContentType)
 
-		str := &serverStream{r: r, w: w, respStream: desc.ClientStreams, codec: codec}
+		str := &serverStream{r: r, w: w, respStream: desc.ClientStreams, streamWriter: streamWriter, streamReader: streamReader}
 		sts := internal.ServerTransportStream{Name: info.FullMethod, Stream: str}
 		str.ctx = grpc.NewContextWithServerTransportStream(ctx, &sts)
 		if streamInt != nil {
@@ -404,7 +419,7 @@ func handleStream(svr interface{}, serviceName string, desc *grpc.StreamDesc, st
 			tr.Details = statProto.Details
 		}
 
-		writeProtoMessage(w, codec, &tr, true)
+		streamWriter(&tr, true)
 	}
 }
 
@@ -456,7 +471,9 @@ type serverStream struct {
 	ctx context.Context
 	// respStream is set to indicate whether client expects stream response; unary if false
 	respStream bool
-	codec      encoding.CodecV2
+
+	streamWriter streamWriter
+	streamReader streamReader
 
 	// rmu serializes access to r and protects recvd
 	rmu sync.Mutex
@@ -522,7 +539,7 @@ func (s *serverStream) SendMsg(m interface{}) error {
 	}
 
 	s.headersSent = true // sent implicitly
-	err := writeProtoMessage(s.w, s.codec, m, false)
+	err := s.streamWriter(m, false)
 	if err != nil {
 		s.writeFailed = true
 	}
@@ -539,21 +556,17 @@ func (s *serverStream) RecvMsg(m interface{}) error {
 
 	s.recvd++
 
-	size, err := readSizePreface(s.r.Body)
+	msg, err := s.streamReader()
 	if err != nil {
 		return err
 	}
 
-	err = readProtoMessage(s.r.Body, s.codec, size, m)
-	if err == io.EOF {
-		return io.ErrUnexpectedEOF
-	} else if err != nil {
+	if err := msg.Decode(m); err != nil {
 		return err
 	}
 
 	if !s.respStream {
-		_, err = readSizePreface(s.r.Body)
-		if err != io.EOF {
+		if _, err := s.streamReader(); err != io.EOF {
 			// client tried to send >1 message!
 			return status.Error(codes.InvalidArgument, "method accepts 1 request message but client sent >1")
 		}

--- a/httpgrpc/server.go
+++ b/httpgrpc/server.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"mime"
 	"net/http"
 	"path"
 	"strconv"
@@ -266,7 +265,7 @@ func handleMethod(svr interface{}, serviceName string, desc *grpc.MethodDesc, un
 		}
 
 		contentType := r.Header.Get("Content-Type")
-		codec := getUnaryCodec(contentType)
+		codec := getCodecForServerUnaryResponse(contentType)
 		if codec == nil {
 			writeError(w, http.StatusUnsupportedMediaType)
 			return
@@ -363,16 +362,8 @@ func handleStream(svr interface{}, serviceName string, desc *grpc.StreamDesc, st
 
 		contentType := r.Header.Get("Content-Type")
 
-		mediaType, _, _ := mime.ParseMediaType(contentType)
-
-		streamWriter, resContentType := getServerStreamWriter(mediaType, w, http.NewResponseController(w))
-		if streamWriter == nil {
-			writeError(w, http.StatusUnsupportedMediaType)
-			return
-		}
-
-		streamReader := getServerStreamReader(mediaType, r.Body)
-		if streamReader == nil {
+		streamReader, streamWriter, resContentType := getServerStreamReaderAndWriter(contentType, r.Body, w, http.NewResponseController(w))
+		if streamReader == nil || streamWriter == nil {
 			writeError(w, http.StatusUnsupportedMediaType)
 			return
 		}

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -1,0 +1,92 @@
+package sse
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Event represents an SSE event. The decoder only supports the data and event fields.
+type Event struct {
+	Type string
+	Data []byte
+}
+
+type Decoder struct {
+	r *bufio.Reader
+}
+
+// NewDecoder creates a new SSE decoder. The decoder does not implement the full SSE specification.
+// It only supports what we need, which only includes the data and event fields.
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{r: bufio.NewReader(r)}
+}
+
+func (d *Decoder) Decode() (*Event, error) {
+	var current *Event
+	for {
+		line, err := d.r.ReadBytes('\n')
+		line = bytes.TrimRight(line, "\r\n")
+
+		if err == io.EOF {
+			if len(line) != 0 {
+				return nil, io.ErrUnexpectedEOF
+			}
+			if current != nil {
+				if current.Type == "" {
+					current.Type = "message"
+				}
+				return current, nil
+			}
+			return nil, io.EOF
+		} else if err != nil {
+			return nil, err
+		}
+
+		switch {
+		case bytes.HasPrefix(line, []byte("data: ")):
+			payload := line[6:]
+			if current == nil {
+				current = &Event{Data: payload}
+			} else {
+				current.Data = append(current.Data, payload...)
+			}
+		case bytes.HasPrefix(line, []byte("event: ")):
+			if current == nil {
+				current = &Event{}
+			}
+			current.Type = string(line[7:])
+		case len(line) == 0:
+			if current != nil {
+				if current.Type == "" {
+					current.Type = "message"
+				}
+				return current, nil
+			}
+		default:
+			return nil, errors.New("malformed event")
+		}
+	}
+}
+
+type Encoder struct {
+	w io.Writer
+}
+
+// NewEncoder creates a new SSE encoder. The encoder does not implement the full SSE specification.
+// It only supports what we need, which only includes the data and event fields.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{w: w}
+}
+
+func (e *Encoder) Encode(event *Event) error {
+	if event.Type == "" || event.Type == "message" {
+		_, err := fmt.Fprintf(e.w, "data: %s\n\n", event.Data)
+		return err
+	}
+
+	_, err := fmt.Fprintf(e.w, "event: %s\ndata: %s\n\n", event.Type, event.Data)
+	return err
+}

--- a/internal/sse/sse_test.go
+++ b/internal/sse/sse_test.go
@@ -1,0 +1,197 @@
+package sse
+
+import (
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func isSameError(a, b error) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Error() == b.Error()
+}
+
+func TestDecode(t *testing.T) {
+	type Expected struct {
+		Event *Event
+		Error error
+	}
+
+	tests := []struct {
+		Name     string
+		Input    string
+		Expected []Expected
+	}{
+		{
+			Name:  "empty",
+			Input: "",
+			Expected: []Expected{
+				{
+					Error: io.EOF,
+				},
+			},
+		},
+		{
+			Name: "single event",
+			Input: strings.Join([]string{
+				"data: hello",
+				"",
+			}, "\n"),
+			Expected: []Expected{
+				{
+					Event: &Event{
+						Type: "message",
+						Data: []byte("hello"),
+					},
+				},
+			},
+		},
+		{
+			Name: "multiple events",
+			Input: strings.Join([]string{
+				"data: hello",
+				"",
+				"data: world",
+				"",
+			}, "\n"),
+			Expected: []Expected{
+				{
+					Event: &Event{
+						Type: "message",
+						Data: []byte("hello"),
+					},
+				},
+				{
+					Event: &Event{
+						Type: "message",
+						Data: []byte("world"),
+					},
+				},
+			},
+		},
+		{
+			Name: "data crossing multiple lines",
+			Input: strings.Join([]string{
+				"data: hello",
+				"data: world",
+				"",
+			}, "\n"),
+			Expected: []Expected{
+				{
+					Event: &Event{
+						Type: "message",
+						Data: []byte("helloworld"),
+					},
+				},
+			},
+		},
+
+		{
+			Name: "event type",
+			Input: strings.Join([]string{
+				"event: trailer",
+				"data: hello",
+				"",
+			}, "\n"),
+			Expected: []Expected{
+				{
+					Event: &Event{
+						Type: "trailer",
+						Data: []byte("hello"),
+					},
+				},
+			},
+		},
+		{
+			Name: "empty data",
+			Input: strings.Join([]string{
+				"data: ",
+				"",
+			}, "\n"),
+			Expected: []Expected{
+				{
+					Event: &Event{
+						Type: "message",
+						Data: []byte(""),
+					},
+				},
+			},
+		},
+		{
+			Name: "empty event type",
+			Input: strings.Join([]string{
+				"event: ",
+				"data: hello",
+				"",
+			}, "\n"),
+			Expected: []Expected{
+				{
+					Event: &Event{
+						Type: "message",
+						Data: []byte("hello"),
+					},
+				},
+			},
+		},
+		{
+			Name: "missing field name",
+			Input: strings.Join([]string{
+				"foo",
+				"",
+			}, "\n"),
+			Expected: []Expected{
+				{
+					Error: errors.New("malformed event"),
+				},
+			},
+		},
+		{
+			Name: "unsupported field name",
+			Input: strings.Join([]string{
+				"foo: bar",
+				"",
+			}, "\n"),
+			Expected: []Expected{
+				{
+					Error: errors.New("malformed event"),
+				},
+			},
+		},
+		{
+			Name: "unexpected end of input",
+			Input: strings.Join([]string{
+				"data: hello",
+			}, "\n"),
+			Expected: []Expected{
+				{
+					Error: io.ErrUnexpectedEOF,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			decoder := NewDecoder(strings.NewReader(test.Input))
+
+			for _, item := range test.Expected {
+				event, err := decoder.Decode()
+
+				if !reflect.DeepEqual(event, item.Event) {
+					t.Fatalf("unexpected event: %v; expecting %v", event, item.Event)
+				}
+
+				if !isSameError(err, item.Error) {
+					t.Fatalf("unexpected error: %v; expecting %v", err, item.Error)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a JSON/SSE transport as an alternative wire format for streaming RPCs in the HTTP channel, alongside the existing binary proto format.

### Approach

The core idea is to decouple message framing from RPC logic by introducing a `streamReader`/`streamWriter` abstraction layer in a new `streamer.go` file. Both the client and server are refactored to use these function types instead of directly calling size-prefixed proto I/O functions (`readSizePreface`, `readProtoMessage`, `writeProtoMessage`). This makes it straightforward to swap in different wire formats.

Two wire formats are now supported:

- **Proto (default):** Size-prefixed binary protobuf messages, matching the existing behavior. Trailers are indicated by a negative size prefix.
- **JSON/SSE:** The client sends JSON-encoded messages in the request body. The server responds with [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events), where each message is a `data:` event and the final trailer is an event with `event: trailer`. This format is primarily intended for use in the server to support browser-based clients but the client implements this format for testing the SSE streaming server implementation.

The format is selected via a new `ContentType` field on the `Channel` struct (`ContentTypeProto` or `ContentTypeJSON`). On the server side, the format is negotiated from the request's `Content-Type` header — the server selects appropriate reader/writer pairs and may respond with a different content type than the request (e.g. request `application/json` → response `text/event-stream`).

### Changes

- **`internal/sse/`** — New package with a minimal SSE encoder and decoder (only `data` and `event` fields, which is all that's needed).
- **`httpgrpc/io.go`** — Defines `streamReader`/`streamWriter` function types and factory functions that create format-specific readers and writers for both client and server roles.
- **`httpgrpc/server.go`** — Refactored `handleStream` and `serverStream` to use `streamReader`/`streamWriter` instead of direct proto I/O. Error detail headers now always use proto encoding regardless of the request content type.
- **`httpgrpc/client.go`** — Refactored `clientStream` to use `streamWriter` for sending and `streamReader` (created from the response's `Content-Type`) for receiving. Added `ContentType` enum and content-type accessor methods to `Channel`.
- **`httpgrpc/protocol_versions.go`** — Added `EventStreamContentType` constant, removed unused `getStreamingCodec`.
- **`httpgrpc/httpgrpc_test.go`** — Added `TestJSONSSEServer` that runs the full channel test suite over JSON/SSE.