### PR TITLE
httpgrpc: align X-GRPC-Details encoding with unary CodecV2 (fix JSON clients)

### DIFF
--- a/httpgrpc/client.go
+++ b/httpgrpc/client.go
@@ -25,10 +25,10 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/fullstorydev/grpchan/internal"
@@ -135,7 +135,7 @@ func (ch *Channel) Invoke(ctx context.Context, methodName string, req, resp inte
 		}
 	}
 
-	if stat := statFromResponse(reply); stat.Code() != codes.OK {
+	if stat := statFromResponse(reply, codec); stat.Code() != codes.OK {
 		return stat.Err()
 	}
 
@@ -177,7 +177,8 @@ func (ch *Channel) NewStream(ctx context.Context, desc *grpc.StreamDesc, methodN
 	}
 	req.Header = h
 
-	cs := newClientStream(ctx, cancel, w, desc.ServerStreams, copts, ch.BaseURL, newStreamWriter(w))
+	detailsCodec := codecForUnaryGRPCDetails(ch.useJSONEncoding)
+	cs := newClientStream(ctx, cancel, w, desc.ServerStreams, copts, ch.BaseURL, newStreamWriter(w), detailsCodec)
 	go cs.doHttpCall(ch.Transport, req, r)
 
 	// ensure that context is cancelled, even if caller
@@ -245,6 +246,10 @@ type clientStream struct {
 
 	streamWriter streamWriter
 
+	// detailsCodec unmarshals X-GRPC-Details when a streaming RPC fails before the body
+	// uses the negotiated unary-style encoding (same as Channel.WithJSONEncoding).
+	detailsCodec encoding.CodecV2
+
 	// respStream is set to indicate whether client expects stream response; unary if false
 	respStream bool
 
@@ -278,6 +283,7 @@ func newClientStream(
 	copts *internal.CallOptions,
 	baseUrl *url.URL,
 	streamWriter streamWriter,
+	detailsCodec encoding.CodecV2,
 ) *clientStream {
 	cs := &clientStream{
 		ctx:          ctx,
@@ -285,6 +291,7 @@ func newClientStream(
 		copts:        copts,
 		baseUrl:      baseUrl,
 		streamWriter: streamWriter,
+		detailsCodec: detailsCodec,
 		w:            w,
 		respStream:   recvStream,
 		rCh:          make(chan streamMsg),
@@ -477,7 +484,7 @@ func (cs *clientStream) doHttpCall(transport http.RoundTripper, req *http.Reques
 
 	onReady(nil, md)
 
-	stat := statFromResponse(reply)
+	stat := statFromResponse(reply, cs.detailsCodec)
 	if stat.Code() != codes.OK {
 		statProto := stat.Proto()
 		cs.tr.Code = statProto.Code
@@ -568,7 +575,7 @@ func headersFromContext(ctx context.Context) http.Header {
 	return h
 }
 
-func statFromResponse(reply *http.Response) *status.Status {
+func statFromResponse(reply *http.Response, detailsCodec encoding.CodecV2) *status.Status {
 	code := codeFromHttpStatus(reply.StatusCode)
 	msg := reply.Status
 	codeStrs := strings.SplitN(reply.Header.Get("X-GRPC-Status"), ":", 2)
@@ -589,11 +596,11 @@ func statFromResponse(reply *http.Response) *status.Status {
 				if err != nil {
 					continue
 				}
-				var msg anypb.Any
-				if err := proto.Unmarshal(b, &msg); err != nil {
+				msg := new(anypb.Any)
+				if err := detailsCodec.Unmarshal(mem.BufferSlice{mem.SliceBuffer(b)}, msg); err != nil {
 					continue
 				}
-				details = append(details, &msg)
+				details = append(details, msg)
 			}
 		}
 		if len(details) > 0 {

--- a/httpgrpc/doc.go
+++ b/httpgrpc/doc.go
@@ -56,9 +56,13 @@
 // includes details, they are attached via one or more headers named "X-GRPC-Details". If
 // more than one error detail is associated with the status, there will be more than one
 // header, and they will be added to the response in the same order as they appear in the
-// server-side status. The value for the details header is a base64-encoding
-// google.protobuf.Any message, which contains the error detail message. If the handler
-// sends trailers, not just headers, they are encoded as HTTP 1.1 headers, but their names
+// server-side status. Each header value is a base64 (raw URL encoding) of the
+// google.protobuf.Any for that detail, using the same CodecV2 as the unary request and
+// response body (binary protobuf for "application/x-protobuf", JSON for "application/json").
+// This is independent of the HTTP error response body produced by DefaultErrorRenderer
+// (for example "text/plain"), so clients must not infer detail encoding from the response
+// Content-Type on failure. *httpgrpc.Channel uses its JSON mode to pick the matching codec
+// when decoding these headers. If the handler sends trailers, not just headers, they are encoded as HTTP 1.1 headers, but their names
 // are prefixed with "X-GRPC-Trailer-". This allows clients to recover headers and trailers
 // independently, as the server handler intended them.
 //

--- a/httpgrpc/httpgrpc_test.go
+++ b/httpgrpc/httpgrpc_test.go
@@ -12,7 +12,11 @@ import (
 	"github.com/fullstorydev/grpchan"
 	"github.com/fullstorydev/grpchan/grpchantesting"
 	"github.com/fullstorydev/grpchan/httpgrpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestGrpcOverHttp(t *testing.T) {
@@ -147,4 +151,78 @@ func TestJSONSSEServer(t *testing.T) {
 			t.Fatalf("server stream should not have returned any messages")
 		}
 	})
+}
+
+// TestUnaryXGrpcDetailsWireCodec asserts that X-GRPC-Details header payloads use
+// the same encoding as the unary request body (protobuf vs JSON), so the
+// client recovers google.rpc.Status details correctly for both modes.
+func TestUnaryXGrpcDetailsWireCodec(t *testing.T) {
+	detailMsg := &structpb.ListValue{
+		Values: []*structpb.Value{
+			{Kind: &structpb.Value_StringValue{StringValue: "x-grpc-details-wire"}},
+		},
+	}
+	wantAny := new(anypb.Any)
+	if err := anypb.MarshalFrom(wantAny, detailMsg, proto.MarshalOptions{}); err != nil {
+		t.Fatalf("marshal detail any: %v", err)
+	}
+
+	svc := &grpchantesting.TestServer{}
+	reg := grpchan.HandlerMap{}
+	grpchantesting.RegisterTestServiceServer(reg, svc)
+
+	mux := http.NewServeMux()
+	httpgrpc.HandleServices(mux.HandleFunc, "/", reg, nil, nil)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{Handler: mux}
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	u, err := url.Parse(fmt.Sprintf("http://%s", ln.Addr().String()))
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+
+	mkReq := func() *grpchantesting.Message {
+		return &grpchantesting.Message{
+			Code:         int32(codes.FailedPrecondition),
+			ErrorDetails: []*anypb.Any{proto.Clone(wantAny).(*anypb.Any)},
+		}
+	}
+
+	t.Run("protobuf", func(t *testing.T) {
+		cc := &httpgrpc.Channel{Transport: http.DefaultTransport, BaseURL: u}
+		cli := grpchantesting.NewTestServiceClient(cc)
+		_, err := cli.Unary(context.Background(), mkReq())
+		assertUnaryErrorHasDetail(t, err, codes.FailedPrecondition, detailMsg)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		cc := httpgrpc.NewChannel(u, http.DefaultTransport, httpgrpc.WithJSONEncoding(true))
+		cli := grpchantesting.NewTestServiceClient(cc)
+		_, err := cli.Unary(context.Background(), mkReq())
+		assertUnaryErrorHasDetail(t, err, codes.FailedPrecondition, detailMsg)
+	})
+}
+
+func assertUnaryErrorHasDetail(t *testing.T, err error, wantCode codes.Code, wantDetail proto.Message) {
+	t.Helper()
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != wantCode {
+		t.Fatalf("status code: got %v want %v", st.Code(), wantCode)
+	}
+	details := st.Details()
+	if len(details) != 1 {
+		t.Fatalf("status details: got %d want 1 (%v)", len(details), details)
+	}
+	if !proto.Equal(details[0].(proto.Message), wantDetail) {
+		t.Fatalf("status detail mismatch:\ngot  %v\nwant %v", details[0], wantDetail)
+	}
 }

--- a/httpgrpc/protocol_versions.go
+++ b/httpgrpc/protocol_versions.go
@@ -141,3 +141,14 @@ func getClientStreamReader(contentType string, r io.Reader) streamReader {
 
 	return nil
 }
+
+// codecForUnaryGRPCDetails returns the CodecV2 used to marshal and unmarshal
+// google.protobuf.Any values in X-GRPC-Details headers for unary RPCs. It
+// matches the unary request/response body codec (protobuf vs JSON) selected
+// from the request Content-Type or from Channel.WithJSONEncoding on the client.
+func codecForUnaryGRPCDetails(useJSONEncoding bool) encoding.CodecV2 {
+	if useJSONEncoding {
+		return encoding.GetCodecV2(jsonCodecName)
+	}
+	return encoding.GetCodecV2(grpcproto.Name)
+}

--- a/httpgrpc/server.go
+++ b/httpgrpc/server.go
@@ -18,8 +18,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/encoding"
-	grpcproto "google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
@@ -305,9 +303,8 @@ func handleMethod(svr interface{}, serviceName string, desc *grpc.MethodDesc, un
 			}
 			statProto := st.Proto()
 			w.Header().Set("X-GRPC-Status", fmt.Sprintf("%d:%s", statProto.Code, statProto.Message))
-			protoCodec := encoding.GetCodecV2(grpcproto.Name)
 			for _, d := range statProto.Details {
-				buf, err := protoCodec.Marshal(d)
+				buf, err := codec.Marshal(d)
 				if err != nil {
 					continue
 				}


### PR DESCRIPTION
846a4d0 always treated X-GRPC-Details payloads as binary protobuf on the
client (proto.Unmarshal) while the server could emit them with the
negotiated unary CodecV2. JSON clients therefore lost error details, and
protobuf vs JSON was inconsistent with the request/response body encoding.

Marshal details with the same codec as the unary handler, and unmarshal
them on the Channel using codecForUnaryGRPCDetails (including streaming
paths that surface status from headers). Document that details use raw
URL base64 of Any in the unary codec, not the error response Content-Type.

Add TestUnaryXGrpcDetailsWireCodec for protobuf and JSON unary failures.
