### PR TITLE
httpgrpc: return an error from NewChannel and ChannelOption

### DIFF
--- a/httpgrpc/client.go
+++ b/httpgrpc/client.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/textproto"
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding"
+	grpcproto "google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
@@ -35,47 +36,116 @@ import (
 )
 
 // ChannelOption is a function that can be used to configure a Channel.
-type ChannelOption func(*channelOptions)
+type ChannelOption func(*channelOptions) error
 
 type channelOptions struct {
 	// TODO(kellegous): It would be ideal if this were refactored into a protocol abstraction that encapsulates the message-level codec and the framing strategy
 	// into a single object. That would all us to have size-prefixed proto, json+see, connectRPC ... anything else.
-	useJSONEncoding bool
+
+	// codecName is the name the codec was looked up by. It selects the content type
+	// of a request and, with the grpc-over-http protocol defined in this package,
+	// also how streams are framed.
+	//
+	// We preserve this instead of using codec.Name() because this value is
+	// already normalized and safe to compare, case-sensitive, with just ==.
+	codecName string
+	codec     encoding.CodecV2
+}
+
+func (o *channelOptions) setCodec(name string) error {
+	codec, err := codecByName(name)
+	if err != nil {
+		return err
+	}
+	o.codecName, o.codec = name, codec
+	return nil
+}
+
+func defaultChannelOptions() (channelOptions, error) {
+	var opts channelOptions
+	// Default to protobuf binary encoding.
+	if err := opts.setCodec(grpcproto.Name); err != nil {
+		return channelOptions{}, err
+	}
+	return opts, nil
+}
+
+// codecByName looks up a registered codec, reporting an unrecognized name as
+// an error.
+func codecByName(name string) (encoding.CodecV2, error) {
+	codec := encoding.GetCodecV2(name)
+	if codec == nil {
+		return nil, fmt.Errorf("no codec registered for %q", name)
+	}
+	return codec, nil
 }
 
 // WithJSONEncoding configures the channel to use JSON encoding between the client and server.
 // For unary calls, the request and response are JSON values. For streaming calls, the request is
 // a series of JSON values and the response is SSE events containing JSON values.
 func WithJSONEncoding(useJSONEncoding bool) ChannelOption {
-	return func(o *channelOptions) {
-		o.useJSONEncoding = useJSONEncoding
+	return func(o *channelOptions) error {
+		name := grpcproto.Name
+		if useJSONEncoding {
+			name = jsonCodecName
+		}
+		// Resolved in both directions, so that a later WithJSONEncoding(false) undoes
+		// an earlier WithJSONEncoding(true) rather than leaving JSON in place.
+		return o.setCodec(name)
 	}
 }
 
-// NewChannel creates a new Channel with the given base URL and transport.
-// The ChannelOption functions can be used to configure the Channel.
-func NewChannel(baseURL *url.URL, transport http.RoundTripper, opts ...ChannelOption) *Channel {
-	c := &Channel{
+// NewChannel creates a new Channel with the given base URL and transport, both of
+// which are required. The ChannelOption functions can be used to configure the
+// Channel. The error reports a channel that cannot be configured as asked.
+func NewChannel(baseURL *url.URL, transport http.RoundTripper, opts ...ChannelOption) (*Channel, error) {
+	if err := checkChannelParams(baseURL, transport); err != nil {
+		return nil, err
+	}
+	chOpts, err := defaultChannelOptions()
+	if err != nil {
+		return nil, err
+	}
+	for _, opt := range opts {
+		if err := opt(&chOpts); err != nil {
+			return nil, err
+		}
+	}
+	return &Channel{
 		BaseURL:   baseURL,
 		Transport: transport,
-	}
-
-	for _, opt := range opts {
-		opt(&c.channelOptions)
-	}
-
-	return c
+		opts:      &chOpts,
+	}, nil
 }
 
-// Channel is used as a connection for GRPC requests issued over HTTP 1.1. The
-// server endpoint is configured using the BaseURL field, and the Transport can
-// also be configured. Both of those fields must be specified.
+func checkChannelParams(baseURL *url.URL, transport http.RoundTripper) error {
+	if baseURL == nil {
+		return errors.New("channel base URL is required")
+	}
+	if transport == nil {
+		return errors.New("channel transport is required")
+	}
+	return nil
+}
+
+// Channel is used as a connection for GRPC requests issued over HTTP 1.1.
+// Values should be created using the NewChannel constructor.
 //
-// It implements version 1 of the GRPC-over-HTTP transport protocol.
+// For backwards compatibility, it is still allowed to construct the channel
+// via a struct literal, as long as both Transport and BaseURL fields are set
+// to non-nil values. Construction via struct literal produces a Channel with
+// all default behavior; use of NewChannel is required to provide channel
+// options.
+//
+// It implements version 1 of the GRPC-over-HTTP transport protocol defined
+// in this package.
 type Channel struct {
 	Transport http.RoundTripper
 	BaseURL   *url.URL
-	channelOptions
+	// opts is nil when the channel was built as a struct literal, which is the
+	// older and still supported form, and so carries all default behavior. A
+	// non-nil value means NewChannel already validated the configuration.
+	opts *channelOptions
 }
 
 var _ grpc.ClientConnInterface = (*Channel)(nil)
@@ -85,17 +155,22 @@ var grpcDetailsHeader = textproto.CanonicalMIMEHeaderKey("X-GRPC-Details")
 // Invoke satisfies the grpchan.Channel interface and supports sending unary
 // RPCs via the in-process channel.
 func (ch *Channel) Invoke(ctx context.Context, methodName string, req, resp interface{}, opts ...grpc.CallOption) error {
+	chOpts, err := ch.channelOptions()
+	if err != nil {
+		return err
+	}
 	copts := internal.GetCallOptions(opts)
 
 	reqUrl := *ch.BaseURL
 	reqUrl.Path = path.Join(reqUrl.Path, methodName)
 	reqUrlStr := reqUrl.String()
-	ctx, err := internal.ApplyPerRPCCreds(ctx, copts, reqUrlStr, reqUrl.Scheme == "https")
+	ctx, err = internal.ApplyPerRPCCreds(ctx, copts, reqUrlStr, reqUrl.Scheme == "https")
 	if err != nil {
 		return err
 	}
 
-	h, codec := getHeadersAndCodecForClientUnaryRequest(ctx, ch.useJSONEncoding)
+	codec := chOpts.codec
+	h := getHeadersForClientUnaryRequest(ctx, chOpts)
 	buf, err := codec.Marshal(req)
 	if err != nil {
 		return err
@@ -120,8 +195,8 @@ func (ch *Channel) Invoke(ctx context.Context, methodName string, req, resp inte
 	respCh := make(chan struct{})
 	go func() {
 		defer close(respCh)
-		b, err = ioutil.ReadAll(reply.Body)
-		reply.Body.Close()
+		b, err = io.ReadAll(reply.Body)
+		_ = reply.Body.Close()
 	}()
 
 	if len(copts.Peer) > 0 {
@@ -154,31 +229,35 @@ func (ch *Channel) Invoke(ctx context.Context, methodName string, req, resp inte
 // NewStream satisfies the grpchan.Channel interface and supports sending
 // streaming RPCs via the in-process channel.
 func (ch *Channel) NewStream(ctx context.Context, desc *grpc.StreamDesc, methodName string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	chOpts, err := ch.channelOptions()
+	if err != nil {
+		return nil, err
+	}
 	copts := internal.GetCallOptions(opts)
 
 	reqUrl := *ch.BaseURL
 	reqUrl.Path = path.Join(reqUrl.Path, methodName)
 	reqUrlStr := reqUrl.String()
-	ctx, err := internal.ApplyPerRPCCreds(ctx, copts, reqUrlStr, reqUrl.Scheme == "https")
+	ctx, err = internal.ApplyPerRPCCreds(ctx, copts, reqUrlStr, reqUrl.Scheme == "https")
 	if err != nil {
 		return nil, err
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
 
-	h, newStreamWriter := getHeadersAndCodecForClientStreamingRequest(ctx, ch.useJSONEncoding)
+	h, newStreamWriter := getHeadersAndWriterForClientStreamingRequest(ctx, chOpts)
 
 	// Intercept r.Close() so we can control the error sent across to the writer thread.
 	r, w := io.Pipe()
-	req, err := http.NewRequest("POST", reqUrlStr, ioutil.NopCloser(r))
+	req, err := http.NewRequest("POST", reqUrlStr, io.NopCloser(r))
 	if err != nil {
 		cancel()
 		return nil, err
 	}
 	req.Header = h
 
-	detailsCodec := codecForUnaryGRPCDetails(ch.useJSONEncoding)
-	cs := newClientStream(ctx, cancel, w, desc.ServerStreams, copts, ch.BaseURL, newStreamWriter(w), detailsCodec)
+	// The details in X-GRPC-Details are encoded with the same codec as the body.
+	cs := newClientStream(ctx, cancel, w, desc.ServerStreams, copts, ch.BaseURL, newStreamWriter(w), chOpts.codec)
 	go cs.doHttpCall(ch.Transport, req, r)
 
 	// ensure that context is cancelled, even if caller
@@ -187,6 +266,19 @@ func (ch *Channel) NewStream(ctx context.Context, desc *grpc.StreamDesc, methodN
 	runtime.SetFinalizer(ret, func(*clientStreamWrapper) { cancel() })
 
 	return ret, nil
+}
+
+func (ch *Channel) channelOptions() (channelOptions, error) {
+	// These fields are exported and mutable, so we check them on every call.
+	err := checkChannelParams(ch.BaseURL, ch.Transport)
+	if err != nil {
+		return channelOptions{}, err
+	}
+	if ch.opts != nil {
+		// Configured and validated by NewChannel.
+		return *ch.opts, nil
+	}
+	return defaultChannelOptions()
 }
 
 type clientStreamWrapper struct {
@@ -469,8 +561,8 @@ func (cs *clientStream) doHttpCall(transport http.RoundTripper, req *http.Reques
 		return
 	}
 	defer func() {
-		ioutil.ReadAll(reply.Body)
-		reply.Body.Close()
+		_, _ = io.ReadAll(reply.Body)
+		_ = reply.Body.Close()
 	}()
 
 	if len(cs.copts.Peer) > 0 {

--- a/httpgrpc/httpgrpc_test.go
+++ b/httpgrpc/httpgrpc_test.go
@@ -132,7 +132,10 @@ func TestJSONSSEServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse base URL: %v", err)
 	}
-	cc := httpgrpc.NewChannel(u, http.DefaultTransport, httpgrpc.WithJSONEncoding(true))
+	cc, err := httpgrpc.NewChannel(u, http.DefaultTransport, httpgrpc.WithJSONEncoding(true))
+	if err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
 
 	grpchantesting.RunChannelTestCases(t, cc, false)
 
@@ -202,9 +205,12 @@ func TestUnaryXGrpcDetailsWireCodec(t *testing.T) {
 	})
 
 	t.Run("json", func(t *testing.T) {
-		cc := httpgrpc.NewChannel(u, http.DefaultTransport, httpgrpc.WithJSONEncoding(true))
+		cc, err := httpgrpc.NewChannel(u, http.DefaultTransport, httpgrpc.WithJSONEncoding(true))
+		if err != nil {
+			t.Fatalf("failed to create channel: %v", err)
+		}
 		cli := grpchantesting.NewTestServiceClient(cc)
-		_, err := cli.Unary(context.Background(), mkReq())
+		_, err = cli.Unary(context.Background(), mkReq())
 		assertUnaryErrorHasDetail(t, err, codes.FailedPrecondition, detailMsg)
 	})
 }
@@ -225,4 +231,68 @@ func assertUnaryErrorHasDetail(t *testing.T, err error, wantCode codes.Code, wan
 	if !proto.Equal(details[0].(proto.Message), wantDetail) {
 		t.Fatalf("status detail mismatch:\ngot  %v\nwant %v", details[0], wantDetail)
 	}
+}
+
+func TestNewChannelValidation(t *testing.T) {
+	u, err := url.Parse("http://127.0.0.1:1")
+	if err != nil {
+		t.Fatalf("failed to parse base URL: %v", err)
+	}
+
+	t.Run("base URL is required", func(t *testing.T) {
+		if _, err := httpgrpc.NewChannel(nil, http.DefaultTransport); err == nil {
+			t.Fatal("expected an error for a nil base URL")
+		}
+	})
+	t.Run("transport is required", func(t *testing.T) {
+		if _, err := httpgrpc.NewChannel(u, nil); err == nil {
+			t.Fatal("expected an error for a nil transport")
+		}
+	})
+	t.Run("both supplied", func(t *testing.T) {
+		ch, err := httpgrpc.NewChannel(u, http.DefaultTransport, httpgrpc.WithJSONEncoding(true))
+		if err != nil {
+			t.Fatalf("failed to create channel: %v", err)
+		}
+		if ch.BaseURL != u || ch.Transport == nil {
+			t.Fatal("channel was not configured with what it was given")
+		}
+	})
+}
+
+// TestChannelMissingFields covers the checks that cannot be made by NewChannel: a
+// Channel may also be built as a struct literal, and its fields are exported, so
+// they can be missing or cleared after construction. Either way the RPC should
+// report the problem, where it used to panic dereferencing a nil base URL.
+func TestChannelMissingFields(t *testing.T) {
+	u, err := url.Parse("http://127.0.0.1:1")
+	if err != nil {
+		t.Fatalf("failed to parse base URL: %v", err)
+	}
+
+	checkFails := func(t *testing.T, ch *httpgrpc.Channel) {
+		t.Helper()
+		cli := grpchantesting.NewTestServiceClient(ch)
+		if _, err := cli.Unary(context.Background(), &grpchantesting.Message{}); err == nil {
+			t.Error("expected a unary RPC to report the missing field")
+		}
+		if _, err := cli.ServerStream(context.Background(), &grpchantesting.Message{}); err == nil {
+			t.Error("expected a streaming RPC to report the missing field")
+		}
+	}
+
+	t.Run("struct literal without base URL", func(t *testing.T) {
+		checkFails(t, &httpgrpc.Channel{Transport: http.DefaultTransport})
+	})
+	t.Run("struct literal without transport", func(t *testing.T) {
+		checkFails(t, &httpgrpc.Channel{BaseURL: u})
+	})
+	t.Run("field cleared after NewChannel", func(t *testing.T) {
+		ch, err := httpgrpc.NewChannel(u, http.DefaultTransport)
+		if err != nil {
+			t.Fatalf("failed to create channel: %v", err)
+		}
+		ch.BaseURL = nil
+		checkFails(t, ch)
+	})
 }

--- a/httpgrpc/protocol_versions.go
+++ b/httpgrpc/protocol_versions.go
@@ -42,13 +42,16 @@ const (
 )
 
 const (
-	// Non-standard and experimental; uses the `jsonpb.Marshaler` by default.
-	// Use `encoding.RegisterCodecV2` to override the default encoder with a custom encoder.
-	// Unary calls use JSON encoding for the request and response. Streaming calls from the
-	// client to the server use JSON encoding with mutiple values. Streaming calls from the
-	// server to the client use SSE encoding with multiple events.
-	ApplicationJson = "application/json"
+	// *Non-standard and experimental.*
+	//
+	// The implementation uses `protojson` for encoding/decoding by default. Use
+	// `encoding.RegisterCodecV2` to override the default encoder with a custom encoder.
+	// Unary calls use JSON encoding for the request and response. Streaming requests from
+	// the client use JSON encoding with multiple values concatenated together. Streaming
+	// responses from the server use SSE (server-side events) encoding with multiple events.
+	// The final status and trailer metadata is encoded as a trailing event.
 
+	ApplicationJson        = "application/json"
 	EventStreamContentType = "text/event-stream"
 )
 
@@ -90,35 +93,38 @@ func getServerStreamReaderAndWriter(contentType string, r io.Reader, w io.Writer
 	return nil, nil, ""
 }
 
-// getHeadersAndCodecForClientUnaryRequest returns the headers and codec to use to handle a unary request on
-// the client, based on the the configuration of the client (currently whether to use JSON encoding).
-func getHeadersAndCodecForClientUnaryRequest(ctx context.Context, useJSONEncoding bool) (http.Header, encoding.CodecV2) {
+// getHeadersForClientUnaryRequest returns the headers to use for a unary request on
+// the client. This protocol pairs each message format with a content type, so the
+// codec the channel was configured with is what selects it.
+func getHeadersForClientUnaryRequest(ctx context.Context, opts channelOptions) http.Header {
 	h := headersFromContext(ctx)
-	if useJSONEncoding {
+	if opts.codecName == jsonCodecName {
 		h.Set("Content-Type", ApplicationJson)
-		return h, encoding.GetCodecV2(jsonCodecName)
+	} else {
+		h.Set("Content-Type", UnaryRpcContentType_V1)
 	}
-
-	h.Set("Content-Type", UnaryRpcContentType_V1)
-	return h, encoding.GetCodecV2(grpcproto.Name)
+	return h
 }
 
-// getHeadersAndCodecForClientStreamingRequest returns the headers and writer to use to handle a streaming request on
-// the client, based on the the configuration of the client (currently whether to use JSON encoding).
-func getHeadersAndCodecForClientStreamingRequest(ctx context.Context, useJSONEncoding bool) (http.Header, func(w io.Writer) streamWriter) {
+// getHeadersAndWriterForClientStreamingRequest returns the headers and the writer to
+// use for a streaming request on the client. As with a unary request the codec
+// selects the content type, and here it selects the framing as well: a JSON
+// stream is a sequence of JSON values answered with server-sent events, where a
+// proto stream is size-prefixed in both directions.
+func getHeadersAndWriterForClientStreamingRequest(ctx context.Context, opts channelOptions) (http.Header, func(w io.Writer) streamWriter) {
 	h := headersFromContext(ctx)
-	if useJSONEncoding {
+	if opts.codecName == jsonCodecName {
 		h.Set("Content-Type", ApplicationJson)
 		h.Set("Accept", EventStreamContentType)
 		return h, func(w io.Writer) streamWriter {
-			return newJSONWriter(w, encoding.GetCodecV2(jsonCodecName))
+			return newJSONWriter(w, opts.codec)
 		}
 	}
 
 	h.Set("Content-Type", StreamRpcContentType_V1)
 	h.Set("Accept", StreamRpcContentType_V1)
 	return h, func(w io.Writer) streamWriter {
-		return newSizePrefixedWriter(w, encoding.GetCodecV2(grpcproto.Name))
+		return newSizePrefixedWriter(w, opts.codec)
 	}
 }
 
@@ -140,15 +146,4 @@ func getClientStreamReader(contentType string, r io.Reader) streamReader {
 	}
 
 	return nil
-}
-
-// codecForUnaryGRPCDetails returns the CodecV2 used to marshal and unmarshal
-// google.protobuf.Any values in X-GRPC-Details headers for unary RPCs. It
-// matches the unary request/response body codec (protobuf vs JSON) selected
-// from the request Content-Type or from Channel.WithJSONEncoding on the client.
-func codecForUnaryGRPCDetails(useJSONEncoding bool) encoding.CodecV2 {
-	if useJSONEncoding {
-		return encoding.GetCodecV2(jsonCodecName)
-	}
-	return encoding.GetCodecV2(grpcproto.Name)
 }


### PR DESCRIPTION
Give `NewChannel` and `ChannelOption` an error result. `NewChannel` returns an error if the base URL and transport are missing or if any option produces an error. The immediate benefit is minor: it allows us to eagerly resolve the codec to use. But this signature is also forward-looking as it allows adding options later that require validation, where we'd want to fail fast from the constructor if an invalid option (or an invalid combination thereof) is provided.

This is safe to do right now because `NewChannel` and `ChannelOption` in their current form (that do _not_ return errors) **have never been released**: the latest release, v1.1.2, predates the change that added them (#84). Once there's a release, the signatures are effectively frozen.

A `*Channel` can still be built as a struct literal, which is the older and released form, so the same fields are checked on every RPC rather than only at construction. The fields are exported, so they could be cleared after construction, which is why we check them for every RPC, even if `NewChannel` were used to create the value. RPCs will now report a comprehensible error instead of panic'ing due to dereferencing a nil pointer.

The options move off the embedded struct and behind a pointer that stays nil until `NewChannel` validates one. This is convenient in that it means "default options" don't have to be a zero-valued struct, so they can carry non-zero default values (like a non-nil codec).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change for unreleased `NewChannel`/`ChannelOption` signatures and a behavior change on misconfigured channels (errors vs panics); wire encoding paths are refactored but should be equivalent when codecs are registered.
> 
> **Overview**
> **`NewChannel` and `ChannelOption` now return errors**, so construction fails fast when the base URL or transport is missing or when an option cannot be applied (e.g. unknown codec). Options are applied onto validated `channelOptions` stored behind `opts` on `*Channel` instead of an embedded `useJSONEncoding` flag.
> 
> Channel encoding is driven by a **resolved `CodecV2` and codec name** (default protobuf; `WithJSONEncoding` toggles JSON and can be undone with `WithJSONEncoding(false)`). Unary and streaming clients pick `Content-Type`, stream framing, and **`X-GRPC-Details`** encoding from that same codec; the separate `codecForUnaryGRPCDetails` helper is removed.
> 
> **`Invoke` and `NewStream` re-check** `BaseURL` and `Transport` on every call so struct-literal channels and fields cleared after `NewChannel` return errors instead of panicking. Tests cover constructor validation and missing/cleared fields; call sites that use `NewChannel` handle the new error return.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc65055c36c4732a14e985a4d6f346b5bf9145a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->