### PR TITLE
httpgrpc: accept either proto message interface in the JSON codec

### DIFF
--- a/httpgrpc/json.go
+++ b/httpgrpc/json.go
@@ -1,12 +1,15 @@
 package httpgrpc
 
 import (
+	"fmt"
+
 	//lint:ignore SA1019 we use the old v1 package because
 	//  we need to support older generated messages
-	"github.com/golang/protobuf/proto"
+	protov1 "github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/mem"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 const jsonCodecName = "json"
@@ -28,17 +31,35 @@ func init() {
 
 type jsonCodec struct{}
 
-func (c jsonCodec) Marshal(v interface{}) (mem.BufferSlice, error) {
-	msg := proto.MessageV2(v.(proto.Message))
+func (c jsonCodec) Marshal(v any) (mem.BufferSlice, error) {
+	msg, err := asProtoMessage(v)
+	if err != nil {
+		return nil, err
+	}
 	bb, err := grpcJsonMarshaler.Marshal(msg)
 	return mem.BufferSlice{mem.SliceBuffer(bb)}, err
 }
 
-func (c jsonCodec) Unmarshal(data mem.BufferSlice, v interface{}) error {
-	msg := proto.MessageV2(v.(proto.Message))
+func (c jsonCodec) Unmarshal(data mem.BufferSlice, v any) error {
+	msg, err := asProtoMessage(v)
+	if err != nil {
+		return err
+	}
 	return grpcJsonUnmarshaler.Unmarshal(data.Materialize(), msg)
 }
 
 func (c jsonCodec) Name() string {
 	return jsonCodecName
+}
+
+func asProtoMessage(v any) (proto.Message, error) {
+	msg, ok := v.(proto.Message)
+	if ok {
+		return msg, nil
+	}
+	msgV1, ok := v.(protov1.Message)
+	if ok {
+		return protov1.MessageV2(msgV1), nil
+	}
+	return nil, fmt.Errorf("%T does not implement proto.Message", v)
 }


### PR DESCRIPTION
The codec asserted its argument to the v1 proto.Message interface, which panics for a message that implements only the v2 interface, such as a dynamicpb value. Accept either, preferring v2 (so that types generated with modern version of protoc-gen-go can skip the V1->V2 conversion), and return an error rather than panicking when it is neither.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized serialization change with backward-compatible v1 support; invalid types now error instead of panic, which is safer for callers.
> 
> **Overview**
> Fixes a **panic** in the gRPC-over-HTTP **JSON codec** when `Marshal`/`Unmarshal` receive messages that only implement **protobuf v2** `proto.Message` (e.g. `dynamicpb`), because the codec previously type-asserted to the **v1** `github.com/golang/protobuf/proto.Message` interface.
> 
> `Marshal` and `Unmarshal` now route values through a new **`asProtoMessage`** helper: use v2 `google.golang.org/protobuf/proto.Message` when present (no conversion for generated types), otherwise accept v1 messages via `protov1.MessageV2`, and **return an error** instead of panicking when the value is neither.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fbca9e52b0b531cbefb78d059a58567a096bd38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->