### PR TITLE
httpgrpc: make abandoning a client stream actually clean it up

### DIFF
--- a/httpgrpc/client.go
+++ b/httpgrpc/client.go
@@ -184,13 +184,62 @@ func (ch *Channel) NewStream(ctx context.Context, desc *grpc.StreamDesc, methodN
 	// ensure that context is cancelled, even if caller
 	// fails to fully consume or cancel the stream
 	ret := &clientStreamWrapper{cs}
-	runtime.SetFinalizer(ret, func(*clientStreamWrapper) { cancel() })
+	runtime.AddCleanup(ret, func(struct{}) { cancel() }, struct{}{})
 
 	return ret, nil
 }
 
+// clientStreamWrapper exists so that a stream the caller abandons still has its
+// context cancelled, by a runtime cleanup, rather than leaving the RPC open
+// forever.
+//
+// Its methods are spelled out rather than promoted from an embedded interface,
+// and each one keeps the wrapper alive across the call it delegates to. Promoted
+// methods would let the wrapper become unreachable as soon as a call descended
+// into the stream underneath it, since nothing on the stack refers to the wrapper
+// any more. A garbage collection during a blocking Recv could then run the
+// cleanup and cancel an RPC that was still very much in progress, surfacing as a
+// spurious "context canceled".
 type clientStreamWrapper struct {
-	grpc.ClientStream
+	stream grpc.ClientStream
+}
+
+var _ grpc.ClientStream = (*clientStreamWrapper)(nil)
+
+func (w *clientStreamWrapper) Header() (metadata.MD, error) {
+	md, err := w.stream.Header()
+	runtime.KeepAlive(w)
+	return md, err
+}
+
+func (w *clientStreamWrapper) Trailer() metadata.MD {
+	md := w.stream.Trailer()
+	runtime.KeepAlive(w)
+	return md
+}
+
+func (w *clientStreamWrapper) CloseSend() error {
+	err := w.stream.CloseSend()
+	runtime.KeepAlive(w)
+	return err
+}
+
+func (w *clientStreamWrapper) Context() context.Context {
+	ctx := w.stream.Context()
+	runtime.KeepAlive(w)
+	return ctx
+}
+
+func (w *clientStreamWrapper) SendMsg(m interface{}) error {
+	err := w.stream.SendMsg(m)
+	runtime.KeepAlive(w)
+	return err
+}
+
+func (w *clientStreamWrapper) RecvMsg(m interface{}) error {
+	err := w.stream.RecvMsg(m)
+	runtime.KeepAlive(w)
+	return err
 }
 
 func getPeer(baseUrl *url.URL, tls *tls.ConnectionState) *peer.Peer {
@@ -452,6 +501,21 @@ func (cs *clientStream) doHttpCall(transport http.RoundTripper, req *http.Reques
 		readPipe.CloseWithError(rErr)
 		close(cs.rCh)
 	}()
+
+	// Release the round trip if the context ends while the request body is still
+	// open, which is the case whenever the caller stops using the stream without
+	// calling CloseSend. The transport sends the body by reading from the pipe and
+	// cannot interrupt that read when it is told to abort -- not even by closing
+	// the body -- so RoundTrip would block indefinitely and the deferred close
+	// above, which is what would otherwise release it, is unreachable from here.
+	// Closing the read end is the only thing that ends it.
+	//
+	// Stopping this on the way out matters: the context is not always cancelled,
+	// since a caller that holds on to a finished stream never cancels it.
+	stopOnCancel := context.AfterFunc(cs.ctx, func() {
+		_ = readPipe.CloseWithError(statusFromContextError(cs.ctx.Err()))
+	})
+	defer stopOnCancel()
 
 	onReady := func(err error, headers metadata.MD) {
 		cs.hdErr = err

--- a/httpgrpc/httpgrpc_test.go
+++ b/httpgrpc/httpgrpc_test.go
@@ -7,11 +7,14 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/fullstorydev/grpchan"
 	"github.com/fullstorydev/grpchan/grpchantesting"
 	"github.com/fullstorydev/grpchan/httpgrpc"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -225,4 +228,148 @@ func assertUnaryErrorHasDetail(t *testing.T, err error, wantCode codes.Code, wan
 	if !proto.Equal(details[0].(proto.Message), wantDetail) {
 		t.Fatalf("status detail mismatch:\ngot  %v\nwant %v", details[0], wantDetail)
 	}
+}
+
+// TestStreamSurvivesGC guards the finalizer that cancels an abandoned stream's
+// context against cancelling one that is still being used.
+//
+// The finalizer is attached to the wrapper value handed back to the caller. If
+// that wrapper's methods were promoted from an embedded interface, the wrapper
+// would fall out of reach as soon as a call descended into the stream underneath
+// it, since nothing on the stack refers to it any more. A garbage collection
+// during a blocking Recv would then run the finalizer and cancel an RPC that was
+// still in progress, surfacing as a spurious "context canceled" in place of
+// whatever really ended the call. With collections forced, that reproduced on
+// every attempt.
+func TestStreamSurvivesGC(t *testing.T) {
+	svr := &grpchantesting.TestServer{}
+	reg := grpchan.HandlerMap{}
+	grpchantesting.RegisterTestServiceServer(reg, svr)
+
+	var mux http.ServeMux
+	httpgrpc.HandleServices(mux.HandleFunc, "/", reg, nil, nil)
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed it listen on socket: %v", err)
+	}
+	httpServer := http.Server{Handler: &mux}
+	go httpServer.Serve(l)
+	defer httpServer.Close()
+
+	u, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", l.Addr().(*net.TCPAddr).Port))
+	if err != nil {
+		t.Fatalf("failed to parse base URL: %v", err)
+	}
+	cc := httpgrpc.Channel{Transport: http.DefaultTransport, BaseURL: u}
+	cli := grpchantesting.NewTestServiceClient(&cc)
+
+	for i := 0; i < 5; i++ {
+		// The deadline is what should end this call: the server sleeps for far
+		// longer, so the stream stays blocked in Recv throughout.
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		ss, err := cli.ServerStream(ctx, &grpchantesting.Message{Count: 3, DelayMillis: 500})
+		if err != nil {
+			cancel()
+			t.Fatalf("opening stream failed: %v", err)
+		}
+
+		// Collect aggressively while the call is blocked, and make no further use of
+		// ss afterwards, so nothing but the wrapper's own methods can keep it
+		// reachable for the duration of the call.
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for j := 0; j < 20; j++ {
+				runtime.GC()
+				time.Sleep(2 * time.Millisecond)
+			}
+		}()
+		_, err = ss.Recv()
+		<-done
+		cancel()
+
+		if got := status.Code(err); got != codes.DeadlineExceeded {
+			t.Fatalf("got %v (%v), want DeadlineExceeded: a collection during the call "+
+				"cancelled a stream that was still in use", got, err)
+		}
+	}
+}
+
+// roundTripWatcher reports when a round trip ends.
+type roundTripWatcher struct {
+	inner http.RoundTripper
+	ended chan error
+}
+
+func (t *roundTripWatcher) RoundTrip(r *http.Request) (*http.Response, error) {
+	resp, err := t.inner.RoundTrip(r)
+	select {
+	case t.ended <- err:
+	default:
+	}
+	return resp, err
+}
+
+// TestAbandonedStreamIsCleanedUp covers what the cleanup on clientStreamWrapper
+// is for: a caller that stops using a stream without finishing or cancelling it
+// should not leave the RPC running.
+//
+// The assertion is deliberately client-side only. Whether the *server* notices is
+// a different question with a different answer: net/http does not watch a
+// connection for a disconnect while a request body remains unread, so a handler
+// finds out by way of a failed read rather than a cancelled context.
+func TestAbandonedStreamIsCleanedUp(t *testing.T) {
+	// A server that never answers, so the round trip stays pending until the
+	// client itself gives up.
+	block := make(chan struct{})
+	defer close(block)
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed it listen on socket: %v", err)
+	}
+	httpServer := http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	})}
+	go httpServer.Serve(l)
+	defer httpServer.Close()
+
+	u, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", l.Addr().(*net.TCPAddr).Port))
+	if err != nil {
+		t.Fatalf("failed to parse base URL: %v", err)
+	}
+	transport := &roundTripWatcher{inner: http.DefaultTransport, ended: make(chan error, 1)}
+	cc := httpgrpc.Channel{Transport: transport, BaseURL: u}
+
+	// Open a stream and send on it, then abandon it: no CloseSend, no cancel. It
+	// is created on a goroutine that then exits, so no stack frame keeps the
+	// stream reachable and it can actually be collected.
+	desc := &grpc.StreamDesc{StreamName: "Abandoned", ServerStreams: true, ClientStreams: true}
+	started := make(chan error, 1)
+	go func() {
+		stream, err := cc.NewStream(context.Background(), desc, "/test.Abandoned/Abandoned")
+		if err != nil {
+			started <- err
+			return
+		}
+		started <- stream.SendMsg(&grpchantesting.Message{})
+	}()
+	if err := <-started; err != nil {
+		t.Fatalf("failed to start the stream: %v", err)
+	}
+
+	for i := 0; i < 100; i++ {
+		runtime.GC()
+		select {
+		case err := <-transport.ended:
+			if err == nil {
+				t.Fatalf("round trip ended without an error, so the stream was not abandoned")
+			}
+			t.Logf("abandoned stream torn down after %d collections: %v", i+1, err)
+			return
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	t.Fatal("the abandoned stream's round trip never ended, so its goroutine and " +
+		"connection are still held")
 }


### PR DESCRIPTION
A stream's context is cancelled once the caller stops using it, so that an abandoned RPC does not stay open forever. Unfortunately, neither half of that worked perfectly.

On the "context is cancelled once the caller stops using it" half, it could possibly cancel stream still in use. This isn't likely in real application code since a real client would try to exhaust the stream in a loop and get the final result/trailers. But a timeout test (in `grpchantesting`) had a simple formulation that just called `stream.RecvMsg` and then no further references to `stream` after that. It wanted to assert that the one call failed with a timeout. But it meant that as soon as we enter `RecvMsg`, the `stream` wrapper is no longer reachable and can be GC'ed, while we're still in the middle of trying to receive a message. Oops. The solution is to use `runtime.KeepAlive` in the wrapper's methods to make sure the wrapper is reachable through the end of all such operations.

On the "abandoned RPC does not stay open forever" half, this simply didn't work. It would cancel the operation, but the underlying network round trip would remain stuck in a `Read` call that wouldn't unblock. The transport writes the request body by reading from a pipe, and cannot interrupt that read when the context is cancelled. So the solution is to watch for context and Close the read end of the pipe when it's canceled (achieved via `context.AfterFunc`).

Just for modernization/improvement, swaps out the call to `runtime.SetFinalizer` to instead use the newer `runtime.AddCleanup`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client stream lifecycle, context cancellation, and HTTP round-trip teardown; bugs could cause leaked connections or incorrect errors on streaming RPCs.
> 
> **Overview**
> Fixes **httpgrpc** client streaming so abandoning a stream tears down the HTTP round trip, while streams still in use are not cancelled by garbage collection.
> 
> **Abandoned streams:** When the caller drops a stream without `CloseSend` or cancel, `runtime.AddCleanup` on `clientStreamWrapper` still cancels the stream context. `doHttpCall` now registers `context.AfterFunc` to **close the request-body pipe’s read end** on cancel, because the transport cannot stop a blocked body read otherwise and `RoundTrip` would hang forever.
> 
> **Active streams:** The wrapper no longer embeds `grpc.ClientStream`; it delegates through explicit methods that call **`runtime.KeepAlive(w)`** so a GC during a blocking `Recv` cannot run cleanup and yield spurious **context canceled** instead of the real error (e.g. deadline).
> 
> Adds **`TestStreamSurvivesGC`** and **`TestAbandonedStreamIsCleanedUp`** for these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de4babba50cffa61b10831b38879bbf316435d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->